### PR TITLE
feat(projects/boq): revamp project-BOQ/BCS workflow, migration logic,…

### DIFF
--- a/crm/src/components/table/data-table.tsx
+++ b/crm/src/components/table/data-table.tsx
@@ -83,6 +83,7 @@ export function DataTable<TData extends Record<string, any>>({
   // Get current filter state for dependency tracking
   const currentGlobalFilter = table.getState().globalFilter;
   const currentColumnFilters = table.getState().columnFilters;
+  const expandedState = table.getState().expanded;
 
   // Memoize filtered data - only recalculate when filter state actually changes
   const filteredRowsData = React.useMemo(() => {
@@ -103,6 +104,18 @@ export function DataTable<TData extends Record<string, any>>({
 
   const virtualRows = rowVirtualizer.getVirtualItems();
   const totalSize = rowVirtualizer.getTotalSize();
+  const shouldVirtualize = !renderSubComponent;
+
+  React.useEffect(() => {
+    if (!shouldVirtualize) return;
+    // Expanded sub-rows change row heights. Force a re-measure so virtualized
+    // row positions stay aligned and do not overlap.
+    if (typeof window === "undefined") return;
+    const rafId = window.requestAnimationFrame(() => {
+      rowVirtualizer.measure();
+    });
+    return () => window.cancelAnimationFrame(rafId);
+  }, [expandedState, rowVirtualizer, shouldVirtualize]);
 
   // ─────────────────────────────────────────────────────────────────────────
   // Minimalist Column Header Renderer
@@ -314,8 +327,8 @@ export function DataTable<TData extends Record<string, any>>({
               ))}
 
 
-              {/* Virtualized rows container */}
-              {!isLoading && rows.length > 0 && (
+              {/* Rows */}
+              {!isLoading && rows.length > 0 && shouldVirtualize && (
                 <div
                   style={{
                     height: `${totalSize}px`,
@@ -394,6 +407,35 @@ export function DataTable<TData extends Record<string, any>>({
                       </div>
                     );
                   })}
+                </div>
+              )}
+
+              {!isLoading && rows.length > 0 && !shouldVirtualize && (
+                <div className="w-full">
+                  {rows.map((row) => (
+                    <div key={row.id} className="flex flex-col">
+                      <div
+                        onClick={() => onRowClick ? onRowClick(row) : undefined}
+                        className={cn(
+                          "grid items-center py-3 px-1 border-b border-border/30 cursor-pointer",
+                          "hover:bg-muted/30 transition-colors gap-4",
+                          gridColsClass,
+                          getRowClassName?.(row)
+                        )}
+                      >
+                        {row.getVisibleCells().map(cell => (
+                          <div key={cell.id} className="text-left overflow-hidden">
+                            {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                          </div>
+                        ))}
+                      </div>
+                      {renderSubComponent && row.getIsExpanded() && (
+                        <div className="w-full bg-white border-b border-border/30 p-2 shadow-inner">
+                          {renderSubComponent(row)}
+                        </div>
+                      )}
+                    </div>
+                  ))}
                 </div>
               )}
 

--- a/crm/src/components/table/standalone-date-filter.tsx
+++ b/crm/src/components/table/standalone-date-filter.tsx
@@ -271,8 +271,8 @@ export function StandaloneDateFilter({
                 </div>
             </PopoverTrigger>
 
-            <PopoverContent className="w-auto min-w-[300px] max-w-[320px] p-0 overflow-hidden" align="end" sideOffset={8}>
-                <div className="p-3 space-y-3">
+            <PopoverContent className="w-auto min-w-[300px] max-w-[320px] p-0 flex flex-col max-h-[380px]" align="end" sideOffset={8}>
+                <div className="p-3 space-y-3 flex-1 overflow-y-auto">
                     <div className="space-y-1.5">
                         <label className="text-[10px] uppercase tracking-wider text-muted-foreground font-medium">
                             Filter type
@@ -373,7 +373,7 @@ export function StandaloneDateFilter({
                     )}
                 </div>
 
-                <div className="flex items-center justify-between gap-2 px-3 py-2.5 border-t border-border bg-muted/30">
+                <div className="flex shrink-0 items-center justify-between gap-2 px-3 py-2.5 border-t border-border bg-muted/30">
                     <Button
                         variant="ghost"
                         size="sm"

--- a/crm/src/constants/boqPackages.ts
+++ b/crm/src/constants/boqPackages.ts
@@ -21,12 +21,38 @@ export type BoqPackageOption = (typeof BOQ_PACKAGE_OPTIONS)[number];
  */
 export function parsePackages(boqType: string | undefined | null): string[] {
   if (!boqType) return [];
+
+  const normalizeArray = (values: unknown[]): string[] => {
+    const seen = new Set<string>();
+    const normalized: string[] = [];
+
+    values.forEach((value) => {
+      const cleaned = String(value ?? "").trim();
+      if (!cleaned || seen.has(cleaned)) return;
+      seen.add(cleaned);
+      normalized.push(cleaned);
+    });
+
+    return normalized;
+  };
+
   try {
     const parsed = JSON.parse(boqType);
-    return Array.isArray(parsed) ? parsed : [boqType];
+    if (Array.isArray(parsed)) {
+      return normalizeArray(parsed);
+    }
   } catch {
-    return boqType ? [boqType] : [];
+    // Legacy values may be comma-separated plain text.
   }
+
+  const cleaned = boqType.trim();
+  if (!cleaned) return [];
+
+  if (cleaned.includes(",")) {
+    return normalizeArray(cleaned.split(","));
+  }
+
+  return [cleaned];
 }
 
 /**

--- a/crm/src/constants/boqZodValidation.ts
+++ b/crm/src/constants/boqZodValidation.ts
@@ -25,6 +25,7 @@ export const boqFormSchema = z.object({
     .optional(),
   // boq_size: z.number().optional(),
   boq_type: z.array(z.string()).optional().default([]),
+  create_bcs: z.boolean().optional().default(false),
   // boq_value: z.number().optional(),
   boq_submission_date: z.string().optional(),
   boq_link: z.string().optional(),
@@ -172,6 +173,7 @@ export const boqDetailsSchema = z.object({
     .nullable()
     .optional(),
   boq_type: z.array(z.string()).optional().default([]),
+  create_bcs: z.boolean().optional().default(false),
   boq_submission_date: z.string().optional(),
   boq_link: z.string().optional(),
   city: z.string().optional(),

--- a/crm/src/pages/BOQS/BOQ.tsx
+++ b/crm/src/pages/BOQS/BOQ.tsx
@@ -192,8 +192,9 @@ const ProjectOverviewCard = ({ boq, contact, company, estimations }: { boq: CRMB
         .reduce((sum, est) => sum + (Number(est.value) || 0), 0);
 
     const totalValue = boqTotalFromRows > 0 ? boqTotalFromRows : (Number(boq?.boq_value) || 0);
-    const profitValue = totalValue - bcsTotalFromRows;
-    const profitPercent = totalValue > 0 ? (profitValue / totalValue) * 100 : 0;
+    const hasBcsValue = bcsTotalFromRows > 0;
+    const profitValue = hasBcsValue ? totalValue - bcsTotalFromRows : 0;
+    const profitPercent = hasBcsValue && totalValue > 0 ? (profitValue / totalValue) * 100 : 0;
 
     return (
         <div className="bg-background rounded-xl border shadow-sm flex flex-col md:flex-row mb-6 overflow-hidden shrink-0">
@@ -220,13 +221,22 @@ const ProjectOverviewCard = ({ boq, contact, company, estimations }: { boq: CRMB
                     </div>
 
                     {!isSalesProfile && (
-                        <div className="flex items-center gap-2 bg-emerald-50/50 p-3 rounded-lg border border-emerald-100/60">
-                            <div className="bg-emerald-100 text-emerald-700 p-1.5 rounded-md">
+                        <div className={cn("flex items-center gap-2 p-3 rounded-lg border", 
+                            !hasBcsValue ? "bg-gray-50/50 border-gray-200" : 
+                            profitValue >= 0 ? "bg-emerald-50/50 border-emerald-100/60" : "bg-red-50/50 border-red-100/60"
+                        )}>
+                            <div className={cn("p-1.5 rounded-md", 
+                                !hasBcsValue ? "bg-gray-100 text-gray-500" :
+                                profitValue >= 0 ? "bg-emerald-100 text-emerald-700" : "bg-red-100 text-red-600"
+                            )}>
                                 <Wallet className="w-4 h-4" />
                             </div>
                             <div>
-                                <p className="text-[10px] uppercase font-bold text-gray-500 tracking-wider">Profit</p>
-                                <p className={cn("text-sm font-bold", profitValue >= 0 ? "text-emerald-700" : "text-red-600")}>
+                                <p className="text-[10px] uppercase font-bold text-gray-500 tracking-wider">{(!hasBcsValue || profitValue >= 0) ? "Profit" : "Loss"}</p>
+                                <p className={cn("text-sm font-bold", 
+                                    !hasBcsValue ? "text-gray-500" :
+                                    profitValue >= 0 ? "text-emerald-700" : "text-red-600"
+                                )}>
                                     ₹{profitValue.toFixed(2)}L ({profitPercent.toFixed(1)}%)
                                 </p>
                             </div>

--- a/crm/src/pages/BOQS/BOQs.tsx
+++ b/crm/src/pages/BOQS/BOQs.tsx
@@ -5,7 +5,6 @@ import { BOQ } from "./BOQ";
 import { useStateSyncedWithParams } from "@/hooks/useSearchParamsManager";
 import { useDialogStore } from "@/store/dialogStore";
 import { Plus } from "lucide-react";
-import { useState, useMemo, useCallback } from "react";
 import { BoqTableView } from "./components/BoqTableView";
 
 const DesktopPlaceholder = () => (
@@ -18,15 +17,6 @@ export const BOQs = () => {
     const { isMobile } = useViewport();
     const [id, setId] = useStateSyncedWithParams<string>("id", "");
     const { openNewBoqDialog } = useDialogStore();
-
-    
-     const userRoleIsAdminOrSales = useMemo(() => {
-        const storedRole = localStorage.getItem('role');
-        if (!storedRole) return false;
-        // Check if it includes 'Admin' or 'Sales'
-        return storedRole.includes('Admin') || storedRole.includes('Sales');
-    }, []);
-    const hideStatusColumnForRole = userRoleIsAdminOrSales;
 
     if (isMobile) {
         return <BoqList />;
@@ -44,9 +34,7 @@ export const BOQs = () => {
                 {/* FIX: Removed overflow-hidden and added min-h-0 */}
                 <div className="flex-1 min-h-0 bg-background rounded-b-lg border-x border-b">
                     <BoqTableView
-                        hideStatusColumn={hideStatusColumnForRole}
                         isStandalonePage={true}
-                        shouldExpandHeight={true}
                         className="h-full" // FIX: Ensure BoqTableView itself fills its container
                     />
                 </div>

--- a/crm/src/pages/BOQS/BoqList.tsx
+++ b/crm/src/pages/BOQS/BoqList.tsx
@@ -104,7 +104,7 @@ export const BoqList = ({ onBoqSelect, activeBoqId }: BoqListProps) => {
     const swrKey = `all-boqs-${JSON.stringify(assignmentFilters)}`;
 
     const { data: boqs, isLoading } = useFrappeGetDocList<EnrichedBoq>("CRM BOQ", {
-        fields: ["name", "boq_name", "boq_status","city","boq_sub_status","boq_submission_date", "boq_type","boq_value", "company", "contact", "boq_size","company.company_name", "contact.first_name","boq_link", "contact.last_name", "modified","assigned_sales"],
+        fields: ["name", "boq_name", "boq_status","city","boq_sub_status","boq_submission_date", "boq_type","create_bcs","boq_value", "company", "contact", "boq_size","company.company_name", "contact.first_name","boq_link", "contact.last_name", "modified","assigned_sales"],
         filters: assignmentFilters,
         limit: 0,
         orderBy: { field: "modified", order: "desc" }

--- a/crm/src/pages/BOQS/EditBoqForm.tsx
+++ b/crm/src/pages/BOQS/EditBoqForm.tsx
@@ -1,6 +1,7 @@
 import { Button } from "@/components/ui/button";
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
+import { Checkbox } from "@/components/ui/checkbox";
 import { Textarea } from "@/components/ui/textarea";
 import { toast } from "@/hooks/use-toast";
 import { useDialogStore } from "@/store/dialogStore";
@@ -78,12 +79,6 @@ export const EditBoqForm = ({ onSuccess }: EditBoqFormProps) => {
       .reduce((sum, e) => sum + (Number(e.value) || 0), 0);
   }, [estimations]);
 
-  const hasLegacyPackage = useMemo(() => {
-    return (estimations || []).some(
-      (est) => (est.package_name || "").trim().toLowerCase() === "legacy"
-    );
-  }, [estimations]);
-
   const companyOptions = useMemo(() => allCompanies?.map(c => ({ label: c.company_nick ? `${c.company_name} (${c.company_nick})` : c.company_name, value: c.name })) || [], [allCompanies]);
 
   const form = useForm<EditBoqFormValues>({
@@ -94,6 +89,26 @@ export const EditBoqForm = ({ onSuccess }: EditBoqFormProps) => {
   const watchedBoqStatus = form.watch("boq_status");
   const selectedCity = form.watch("city");
   const selectedCompany = form.watch("company");
+  const selectedPackages = form.watch("boq_type") || [];
+
+  const existingBcsPackages = useMemo(() => {
+    const packages = new Set<string>();
+    (estimations || []).forEach((est) => {
+      if ((est.document_type || "").trim().toUpperCase() !== "BCS") return;
+      const pkg = (est.package_name || "").trim();
+      if (pkg) packages.add(pkg);
+    });
+    return packages;
+  }, [estimations]);
+
+  const pendingBcsPackages = useMemo(() => {
+    return (selectedPackages || [])
+      .map((pkg: string) => (pkg || "").trim())
+      .filter((pkg: string) => pkg && !existingBcsPackages.has(pkg));
+  }, [selectedPackages, existingBcsPackages]);
+
+  const hasPendingBcsForSelectedPackages = pendingBcsPackages.length > 0;
+  const disableCreateBcsToggle = !hasPendingBcsForSelectedPackages;
 
   const { data: contactsList, isLoading: contactsLoading } = useFrappeGetDocList<CRMContacts>(
     "CRM Contacts",
@@ -117,6 +132,8 @@ export const EditBoqForm = ({ onSuccess }: EditBoqFormProps) => {
         city: initialCityValue || "",
         other_city: initialOtherCityValue,
         boq_type: parsePackages(boqData.boq_type),
+        // Treat this as an explicit action for new packages during edit.
+        create_bcs: false,
         boq_value: Number(boqData.boq_value) || 0,
         boq_size: Number(boqData.boq_size) || 0,
         boq_status: boqData.boq_status || "",
@@ -186,6 +203,7 @@ export const EditBoqForm = ({ onSuccess }: EditBoqFormProps) => {
       if (dataToSave.boq_type && Array.isArray(dataToSave.boq_type)) {
         dataToSave.boq_type = serializePackages(dataToSave.boq_type);
       }
+      dataToSave.create_bcs = dataToSave.create_bcs ? 1 : 0;
       if (dataToSave.city === "Others") {
         dataToSave.city = dataToSave.other_city?.trim() || "";
       }
@@ -310,16 +328,38 @@ export const EditBoqForm = ({ onSuccess }: EditBoqFormProps) => {
                     <PackagesMultiSelect
                       value={field.value || []}
                       onChange={field.onChange}
-                      placeholder={hasLegacyPackage ? "Legacy projects cannot add packages" : "Select packages..."}
-                      disabled={hasLegacyPackage}
+                      placeholder="Select packages..."
                     />
                   </FormControl>
-                  {hasLegacyPackage && (
-                    <p className="text-[11px] text-muted-foreground">
-                      This migrated legacy project is locked. Package changes are disabled to avoid mixing legacy and package-based data.
-                    </p>
-                  )}
                   <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              name="create_bcs"
+              control={form.control}
+              render={({ field }) => (
+                <FormItem className="flex flex-row items-start space-x-3 space-y-0 rounded-md border p-3">
+                  <FormControl>
+                    <Checkbox
+                      checked={!!field.value}
+                      disabled={disableCreateBcsToggle}
+                      onCheckedChange={(checked) => field.onChange(!!checked)}
+                    />
+                  </FormControl>
+                  <div className="space-y-1 leading-none">
+                    <FormLabel>Create BCS tasks for selected packages</FormLabel>
+                    {disableCreateBcsToggle && (
+                      <p className="text-[11px] text-muted-foreground">
+                        No new packages pending for BCS. Add a new package to enable this option.
+                      </p>
+                    )}
+                    {!disableCreateBcsToggle && (
+                      <p className="text-[11px] text-muted-foreground">
+                        New package(s): {pendingBcsPackages.join(", ")}. Enable this to create BCS only for these package(s).
+                      </p>
+                    )}
+                  </div>
                 </FormItem>
               )}
             />

--- a/crm/src/pages/BOQS/EditBoqForm.tsx
+++ b/crm/src/pages/BOQS/EditBoqForm.tsx
@@ -108,7 +108,11 @@ export const EditBoqForm = ({ onSuccess }: EditBoqFormProps) => {
   }, [selectedPackages, existingBcsPackages]);
 
   const hasPendingBcsForSelectedPackages = pendingBcsPackages.length > 0;
-  const disableCreateBcsToggle = !hasPendingBcsForSelectedPackages;
+  const isCreateBcsLocked = useMemo(() => {
+    const hasStoredFlag = Number(boqData?.create_bcs || 0) === 1;
+    return Boolean(hasStoredFlag || existingBcsPackages.size > 0);
+  }, [boqData?.create_bcs, existingBcsPackages]);
+  const disableCreateBcsToggle = isCreateBcsLocked || !hasPendingBcsForSelectedPackages;
 
   const { data: contactsList, isLoading: contactsLoading } = useFrappeGetDocList<CRMContacts>(
     "CRM Contacts",
@@ -132,8 +136,7 @@ export const EditBoqForm = ({ onSuccess }: EditBoqFormProps) => {
         city: initialCityValue || "",
         other_city: initialOtherCityValue,
         boq_type: parsePackages(boqData.boq_type),
-        // Treat this as an explicit action for new packages during edit.
-        create_bcs: false,
+        create_bcs: boqData.create_bcs === 1,
         boq_value: Number(boqData.boq_value) || 0,
         boq_size: Number(boqData.boq_size) || 0,
         boq_status: boqData.boq_status || "",
@@ -145,6 +148,12 @@ export const EditBoqForm = ({ onSuccess }: EditBoqFormProps) => {
       });
     }
   }, [boqData, form]);
+
+  useEffect(() => {
+    if (isCreateBcsLocked && !form.getValues("create_bcs")) {
+      form.setValue("create_bcs", true, { shouldValidate: false, shouldDirty: false });
+    }
+  }, [isCreateBcsLocked, form]);
 
   useEffect(() => {
     const clearFieldsBasedOnStatus = (status: string | undefined) => {
@@ -203,7 +212,7 @@ export const EditBoqForm = ({ onSuccess }: EditBoqFormProps) => {
       if (dataToSave.boq_type && Array.isArray(dataToSave.boq_type)) {
         dataToSave.boq_type = serializePackages(dataToSave.boq_type);
       }
-      dataToSave.create_bcs = dataToSave.create_bcs ? 1 : 0;
+      dataToSave.create_bcs = isCreateBcsLocked ? 1 : (dataToSave.create_bcs ? 1 : 0);
       if (dataToSave.city === "Others") {
         dataToSave.city = dataToSave.other_city?.trim() || "";
       }
@@ -349,12 +358,17 @@ export const EditBoqForm = ({ onSuccess }: EditBoqFormProps) => {
                   </FormControl>
                   <div className="space-y-1 leading-none">
                     <FormLabel>Create BCS tasks for selected packages</FormLabel>
-                    {disableCreateBcsToggle && (
+                    {isCreateBcsLocked && (
+                      <p className="text-[11px] text-muted-foreground">
+                        BCS creation is permanently enabled for this project. New packages will auto-create BCS.
+                      </p>
+                    )}
+                    {!isCreateBcsLocked && disableCreateBcsToggle && (
                       <p className="text-[11px] text-muted-foreground">
                         No new packages pending for BCS. Add a new package to enable this option.
                       </p>
                     )}
-                    {!disableCreateBcsToggle && (
+                    {!isCreateBcsLocked && !disableCreateBcsToggle && (
                       <p className="text-[11px] text-muted-foreground">
                         New package(s): {pendingBcsPackages.join(", ")}. Enable this to create BCS only for these package(s).
                       </p>

--- a/crm/src/pages/BOQS/NewBoqForm.tsx
+++ b/crm/src/pages/BOQS/NewBoqForm.tsx
@@ -1,6 +1,7 @@
 import { Button } from "@/components/ui/button";
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
+import { Checkbox } from "@/components/ui/checkbox";
 import { Textarea } from "@/components/ui/textarea";
 import { toast } from "@/hooks/use-toast";
 import { useDialogStore } from "@/store/dialogStore";
@@ -51,6 +52,7 @@ const boqFormSchema = z.object({
       .optional(),
   // boq_size: z.number().optional(),
   boq_type: z.array(z.string()).optional().default([]),
+  create_bcs: z.boolean().optional().default(false),
   // boq_value: z.number().optional(),
   boq_submission_date: z.string().optional(),
   boq_link: z.string().optional(),
@@ -76,6 +78,13 @@ const boqFormSchema = z.object({
       code: z.ZodIssueCode.custom,
       message: "At least one package is required.",
       path: ['boq_type'],
+    });
+  }
+  if (!data.city || data.city.trim() === "") {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "City is required.",
+      path: ['city'],
     });
   }
   // if (!data.contact || data.contact.trim() === "") {
@@ -186,7 +195,8 @@ export const NewBoqForm = ({ onSuccess }: NewBoqFormProps) => {
   const form = useForm<BoqFormValues>({
     resolver: zodResolver(boqFormSchema),
      defaultValues: { // Set a default boq_status
-        boq_status: "New" // This is important for initial state
+        boq_status: "New", // This is important for initial state
+        create_bcs: false
     },
   });
   
@@ -233,6 +243,7 @@ export const NewBoqForm = ({ onSuccess }: NewBoqFormProps) => {
       company: companyId || "",
       contact: contactIdFromContext || "",
       boq_name: "", boq_size: "", boq_type: [], boq_value: "",
+      create_bcs: false,
       boq_submission_date: "", boq_link: "",
       city:
       
@@ -298,6 +309,7 @@ export const NewBoqForm = ({ onSuccess }: NewBoqFormProps) => {
       if (dataToSubmit.boq_type && Array.isArray(dataToSubmit.boq_type)) {
         dataToSubmit.boq_type = serializePackages(dataToSubmit.boq_type);
       }
+      dataToSubmit.create_bcs = dataToSubmit.create_bcs ? 1 : 0;
 
       if (dataToSubmit.city === "Others") {
         dataToSubmit.city = dataToSubmit.other_city?.trim() || "";
@@ -471,6 +483,21 @@ export const NewBoqForm = ({ onSuccess }: NewBoqFormProps) => {
             <FormMessage />
           </FormItem>
         )} />
+
+        <FormField
+          name="create_bcs"
+          control={form.control}
+          render={({ field }) => (
+            <FormItem className="flex flex-row items-start space-x-3 space-y-0 rounded-md border p-3">
+              <FormControl>
+                <Checkbox checked={!!field.value} onCheckedChange={(checked) => field.onChange(!!checked)} />
+              </FormControl>
+              <div className="space-y-1 leading-none">
+                <FormLabel>Create BCS tasks for selected packages</FormLabel>
+              </div>
+            </FormItem>
+          )}
+        />
         
 
 

--- a/crm/src/pages/BOQS/components/BoqDealStatusCard.tsx
+++ b/crm/src/pages/BOQS/components/BoqDealStatusCard.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import { Button } from '@/components/ui/button';
 import { useDialogStore } from '@/store/dialogStore';
 import { CRMBOQ } from '@/types/NirmaanCRM/CRMBOQ';
-import { SquarePen } from 'lucide-react'; // Assuming SquarePen is used for edit icon
+import { RotateCw, SquarePen } from 'lucide-react'; // Assuming SquarePen is used for edit icon
 
 interface BoqDealStatusCardProps {
     boq: CRMBOQ;
@@ -74,7 +74,7 @@ export const BoqDealStatusCard = ({ boq }: BoqDealStatusCardProps) => {
                 className="border-destructive text-destructive whitespace-nowrap mt-4 sm:mt-0"
                 onClick={handleUpdateDealStatusClick}
             >
-                <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="mr-2.5"><path d="M21.5 2v6h-6M21.34 15.57a10 10 0 1 1-.59-9.21l-5.94 5.94M21.5 8l-5.94-5.94"/></svg>
+                <RotateCw />
                 Update
             </Button>
         </div>

--- a/crm/src/pages/BOQS/components/BoqTableView.tsx
+++ b/crm/src/pages/BOQS/components/BoqTableView.tsx
@@ -18,27 +18,9 @@ import { useUserRoleLists } from '@/hooks/useUserRoleLists';
 import { formatDateWithOrdinal } from '@/utils/FormatDate'; // Your date formatting utility
 import { Button } from '@/components/ui/button';
 import { ChevronRight, ChevronDown } from 'lucide-react';
-import { SlidingTabs } from '@/components/ui/sliding-tabs';
-import { useStateSyncedWithParams } from "@/hooks/useSearchParamsManager";
 import { parsePackages } from "@/constants/boqPackages";
 import { ConnectedProjectEstimationsTable } from './ProjectEstimationsTable';
 import { BoqBcsTaskExport } from './BoqBcsTaskExport';
-
-const normalizeBoqStatus = (status?: string) =>
-    (status || "")
-        .toLowerCase()
-        .replace(/[_-]+/g, " ")
-        .replace(/\s+/g, " ")
-        .trim();
-
-const getStatusFilterValues = (tabStatus: string): string[] => {
-    return [tabStatus];
-};
-
-const shouldShowSubmissionDateForStatus = (tabStatus: string): boolean => {
-    const normalized = normalizeBoqStatus(tabStatus);
-    return normalized === "new" || normalized === "in progress";
-};
 
 
 // Interface for the BOQ data
@@ -63,7 +45,7 @@ interface BOQ {
     city?: string;
     remarks?: string;
     assigned_estimations?: string; // Estimator's email/ID, needs lookup for display name
-    deal_status?: string; 
+    deal_status?: string;
     client_deal_status?: string;
     creation: string;
 }
@@ -77,7 +59,6 @@ interface ProjectEstimationValueRow {
 interface BoqTableViewProps {
     onBoqSelect?: (id: string) => void;
     activeBoqId?: string;
-    // hideStatusColumn prop is removed as status column will always be visible in BoqTableView
     isStandalonePage?: boolean;
     className?: string;
     tableContainerClassName?: string;
@@ -96,12 +77,6 @@ export const BoqTableView = ({
     const role = localStorage.getItem('role');
 
     const showAssignedSalesColumn = role !== "Nirmaan Sales User Profile"
-
-
-    // Use useStateSyncedWithParams for activeTabStatus to persist in URL
-    const [activeTabStatus, setActiveTabStatus] = useStateSyncedWithParams<string>('statusTab', 'All');
-    // In BoqTableView, hideStatusColumn is effectively false, as the column is always defined and visible.
-    const hideStatusColumn = false; // For clarity within this component
 
 
     // --- Data Fetching for all BOQs ---
@@ -229,19 +204,6 @@ export const BoqTableView = ({
     }, [boqs, usersLoading, getUserFullNameByEmail]);
 
 
-    const boqSubmissionDateColumn: DataTableColumnDef<BOQ> = {
-        accessorKey: "boq_submission_date",
-        meta: { title: "Submission Deadline", filterVariant: 'date', enableSorting: true },
-        cell: ({ row }) => (
-            <span className="text-sm text-muted-foreground">
-                    {row.original.boq_submission_date ? formatDateWithOrdinal(new Date(row.original.boq_submission_date)) : '--'}
-            </span>
-        ),
-        enableSorting: true,
-        filterFn: 'dateRange',
-    };
-
-
     // // --- Column Definitions for the DataTable ---
     // const columns = useMemo<DataTableColumnDef<BOQ>[]>(() => [
     //     {
@@ -350,7 +312,7 @@ export const BoqTableView = ({
                 meta: { title: "Project Name", enableSorting: true },
                 cell: ({ row }) => (
                     <Link
-                        to={`/boqs/boq?id=${row.original.name}&statusTab=${activeTabStatus}`}
+                        to={`/boqs/boq?id=${row.original.name}`}
                         className="text-primary font-semibold hover:underline text-left block"
                         title={row.original.boq_name}
                     >
@@ -410,7 +372,13 @@ export const BoqTableView = ({
                 meta: { title: "Added Date", filterVariant: 'date', enableSorting: true },
                 cell: ({ row }) => (
                     <span className="text-sm text-muted-foreground">
-                        {formatDateWithOrdinal(new Date(row.original.creation))}
+                        {row.original.creation
+                            ? new Date(row.original.creation).toLocaleDateString("en-GB", {
+                                day: "numeric",
+                                month: "short",
+                                year: "numeric",
+                            })
+                            : "--"}
                     </span>
                 ),
                 enableSorting: true,
@@ -421,7 +389,13 @@ export const BoqTableView = ({
                 meta: { title: "Last Updated", filterVariant: 'date', enableSorting: true },
                 cell: ({ row }) => (
                     <span className="text-sm  text-muted-foreground">
-                        {formatDateWithOrdinal(new Date(row.original.modified))}
+                        {row.original.modified
+                            ? new Date(row.original.modified).toLocaleDateString("en-GB", {
+                                day: "numeric",
+                                month: "short",
+                                year: "numeric",
+                            })
+                            : "--"}
                     </span>
                 ),
                 enableSorting: true,
@@ -459,12 +433,6 @@ export const BoqTableView = ({
         }
 
 
-        // Conditionally add the boq_submission_date column
-        if (shouldShowSubmissionDateForStatus(activeTabStatus)) {
-            // Insert it before the "Deal Status" column for a logical flow
-            baseColumns.splice(6, 0, boqSubmissionDateColumn); // Insert at index 6 (after boq_value column)
-        }
-
         // Add Actions Column
         baseColumns.push({
             id: 'actions',
@@ -488,7 +456,7 @@ export const BoqTableView = ({
 
         return baseColumns;
 
-    }, [boqs, companyOptions, showAssignedSalesColumn, projectNamesOptions, statusOptions, dealStatusOptions, subStatusOptions, getBoqStatusClass, activeTabStatus, isStandalonePage, navigate, onBoqSelect, hasProjectBoqEntries, projectValueById]);
+    }, [boqs, companyOptions, showAssignedSalesColumn, projectNamesOptions, statusOptions, dealStatusOptions, subStatusOptions, getBoqStatusClass, isStandalonePage, navigate, onBoqSelect, hasProjectBoqEntries, projectValueById]);
 
 
     if (error) return <div className="text-red-500">Error loading BOQs.</div>;
@@ -496,17 +464,11 @@ export const BoqTableView = ({
 
     // --- Dynamic Filters & Visibility passed to useDataTableLogic ---
 
-    // `initialColumnFilters`: Based on the active tab status
-    const initialColumnFilters: ColumnFiltersState = useMemo(() => {
-        if (activeTabStatus !== 'All') { // Only apply filter if a specific tab is selected
-            return [{ id: 'boq_status', value: getStatusFilterValues(activeTabStatus) }];
-        }
-        return [];
-    }, [activeTabStatus]); // Dependency only on activeTabStatus
+    const initialColumnFilters: ColumnFiltersState = [];
 
-    // `initialColumnVisibility`: `boq_status` is always visible now. `actions` depends on `isStandalonePage`.
+    // Keep status visible in the main projects grid.
     const initialColumnVisibility = useMemo(() => ({
-        boq_status: true, // Status column is always visible visually
+        boq_status: true,
         actions: !isStandalonePage // Hide 'actions' column if it's a standalone page
     }), [isStandalonePage]); // Dependency only on isStandalonePage
 
@@ -542,19 +504,13 @@ export const BoqTableView = ({
         // Clear global search when a tab filter is applied/changed.
         tableLogic.setGlobalFilter('');
 
-        // Apply the tab-based status filter based on activeTabStatus
-        const newFilters = activeTabStatus !== 'All'
-            ? [{ id: 'boq_status', value: getStatusFilterValues(activeTabStatus) }]
-            : [];
-        tableLogic.table.setColumnFilters(newFilters);
-
         // Dynamically set 'actions' column visibility
         tableLogic.setColumnVisibility(prev => ({
             ...prev,
             actions: !isStandalonePage
         }));
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [activeTabStatus, isStandalonePage]);
+    }, [isStandalonePage]);
 
 
     // --- Mobile Row Renderer ---
@@ -621,12 +577,12 @@ export const BoqTableView = ({
                 exportValue: (row) => getUserFullNameByEmail(row.assigned_sales || "") || ''
             }
         },
-        { 
-            accessorKey: "owner", 
-            meta: { 
+        {
+            accessorKey: "owner",
+            meta: {
                 exportHeaderName: "Created By",
                 exportValue: (row) => row.owner ? (getUserFullNameByEmail(row.owner) || row.owner) : ''
-            } 
+            }
         },
         { accessorKey: "modified", meta: { exportHeaderName: "Last Modified" } },
         { accessorKey: "boq_link", meta: { exportHeaderName: "BOQ Link" } },
@@ -638,7 +594,7 @@ export const BoqTableView = ({
 
     // NEW: Calculate gridColsClass dynamically based on visible columns
     const calculatedGridColsClass = useMemo(() => {
-        const isSubmissionDateColumnVisible = shouldShowSubmissionDateForStatus(activeTabStatus);
+        const isSubmissionDateColumnVisible = false;
         const isActionsColumnVisible = tableLogic.columnVisibility.actions;
         if (showAssignedSalesColumn) {
             if (isSubmissionDateColumnVisible && isActionsColumnVisible) {
@@ -663,7 +619,7 @@ export const BoqTableView = ({
             return "md:pl-3 md:grid-cols-[40px_1.5fr_1.2fr_1fr_1fr_1.2fr_1.2fr_1fr_60px]";
         }
         return "md:pl-3 md:grid-cols-[40px_1.5fr_1.2fr_1fr_1fr_1.2fr_1.2fr_1fr]";
-    }, [activeTabStatus, tableLogic.columnVisibility.actions, showAssignedSalesColumn]); // Dependencies for this memo
+    }, [tableLogic.columnVisibility.actions, showAssignedSalesColumn]); // Dependencies for this memo
     // NEW: Calculate gridColsClass dynamically based on visible columns
 
 
@@ -687,21 +643,6 @@ export const BoqTableView = ({
 
             headerTitle={<span className="tracking-tight">Projects</span>}
             noResultsMessage="No Projects found."
-            // Minimalist animated tabs with sliding indicator
-            renderTopToolbarActions={
-                <SlidingTabs
-                    tabs={[
-                        { label: 'ALL', value: 'All' },
-                        ...['New', 'In-Progress', 'Won', 'Negotiation', 'Hold', 'Dropped', 'Lost'].map(status => ({
-                            label: status.toUpperCase(),
-                            value: status
-                        }))
-                    ]}
-                    activeTab={activeTabStatus}
-                    onTabChange={setActiveTabStatus}
-                    tabClassName="text-[13px] md:text-[14px]"
-                />
-            }
             renderToolbarActions={(filteredData) => (
                 <div className="flex items-center gap-2">
                     <DataTableExportButton

--- a/crm/src/pages/BOQS/components/ProjectEstimationsTable.tsx
+++ b/crm/src/pages/BOQS/components/ProjectEstimationsTable.tsx
@@ -65,8 +65,6 @@ export const ProjectEstimationsTable = ({
                     <TableHeader className="bg-muted/30 z-10 sticky top-0">
                         <TableRow>
                             <TableHead className="text-[11px] uppercase font-semibold text-muted-foreground tracking-wider">TITLE</TableHead>
-                            <TableHead className="text-[11px] uppercase font-semibold text-muted-foreground tracking-wider text-center">TYPE</TableHead>
-                            <TableHead className="text-[11px] uppercase font-semibold text-muted-foreground tracking-wider text-center">PACKAGE</TableHead>
                             <TableHead className="text-[11px] uppercase font-semibold text-muted-foreground tracking-wider">VALUE</TableHead>
                             <TableHead className="text-[11px] uppercase font-semibold text-muted-foreground tracking-wider text-center">LINK</TableHead>
                             <TableHead className="text-[11px] uppercase font-semibold text-muted-foreground tracking-wider text-center">STATUS</TableHead>
@@ -85,16 +83,6 @@ export const ProjectEstimationsTable = ({
                                     {est.title?.startsWith(`${projectId} - `)
                                         ? est.title.replace(`${projectId} - `, '')
                                         : est.title}
-                                </TableCell>
-                                <TableCell className="text-center">
-                                    <span className={est.document_type === 'BOQ' ? 'bg-blue-100 text-blue-600 px-2.5 py-1 rounded text-[10px] uppercase font-bold tracking-wider' : 'bg-purple-100 text-purple-600 px-2.5 py-1 rounded text-[10px] uppercase font-bold tracking-wider'}>
-                                        {est.document_type}
-                                    </span>
-                                </TableCell>
-                                <TableCell className="text-center">
-                                    <span className="border border-gray-200 px-3 py-1 text-xs rounded bg-white whitespace-nowrap text-gray-600">
-                                        {est.package_name || '--'}
-                                    </span>
                                 </TableCell>
                                 <TableCell className="font-medium text-sm">
                                     {est.value ? `₹${Number(est.value).toFixed(2)} L` : '--'}

--- a/crm/src/pages/Home/HomeHeader.tsx
+++ b/crm/src/pages/Home/HomeHeader.tsx
@@ -77,6 +77,7 @@ import { useFrappeGetDocList } from "frappe-react-sdk";
 import { useEffect, useMemo } from "react";
 import { cn } from "@/lib/utils";
 import { EstimationsReviewTable } from "./components/EstimationsReviewTable";
+import { BoqBcsReviewTable } from "./components/BoqBcsReviewTable";
 
 // --- shadcn/ui Tabs Imports ---
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
@@ -121,7 +122,7 @@ export const HomeHeader = () => {
     const isAdmin = role === 'Nirmaan Admin User Profile';
     const isSalesUser = role === 'Nirmaan Sales User Profile';
     const isEstimationsUser =
-        role === 'Nirmaan Estimations User Profile' || role === 'Nirmaan Estimations Lead Profile'
+        role === 'Nirmaan Estimations User Profile' || role === 'Nirmaan Estimates User Profile' || role === 'Nirmaan Estimations Lead Profile' || role === 'Nirmaan Estimations lead Profile'
 
     const canViewSalesReview = isAdmin || isSalesUser;
     const canViewEstimationsReview = isAdmin || isEstimationsUser;
@@ -183,7 +184,7 @@ export const HomeHeader = () => {
 
                 {(canViewSalesReview || canViewEstimationsReview) && (
                     <Tabs value={activeTab} onValueChange={setActiveTab} className="mb-4">
-                        <TabsList className={cn("grid w-full md:w-[400px]", canViewSalesReview && canViewEstimationsReview ? "grid-cols-2" : "grid-cols-1")}>
+                        <TabsList className={cn("grid w-full md:w-auto", canViewSalesReview && canViewEstimationsReview ? "grid-cols-1 sm:grid-cols-3 md:w-[600px]" : "grid-cols-1 sm:grid-cols-2 md:w-[400px]")}>
                             {canViewSalesReview && (
                                 <TabsTrigger
                                     value="sales_review"
@@ -204,6 +205,17 @@ export const HomeHeader = () => {
                                     )}
                                 >
                                     Estimations Review
+                                </TabsTrigger>
+                            )}
+                            {canViewEstimationsReview && (
+                                <TabsTrigger
+                                    value="boq_bcs_review"
+                                    className={cn(
+                                        "data-[state=active]:bg-destructive data-[state=active]:text-destructive-foreground",
+                                        "data-[state=inactive]:text-muted-foreground data-[state=inactive]:bg-background hover:data-[state=inactive]:bg-accent"
+                                    )}
+                                >
+                                    BOQ/BCS Review
                                 </TabsTrigger>
                             )}
                         </TabsList>
@@ -263,6 +275,12 @@ export const HomeHeader = () => {
                 {canViewEstimationsReview && activeTab === 'estimations_review' && (
                     <div className="flex-1 flex flex-col min-h-0">
                         <EstimationsReviewTable />
+                    </div>
+                )}
+
+                {canViewEstimationsReview && activeTab === 'boq_bcs_review' && (
+                    <div className="flex-1 flex flex-col min-h-0">
+                        <BoqBcsReviewTable />
                     </div>
                 )}
 

--- a/crm/src/pages/Home/components/BoqBcsReviewTable.tsx
+++ b/crm/src/pages/Home/components/BoqBcsReviewTable.tsx
@@ -1,0 +1,94 @@
+import React, { useMemo } from "react";
+import { useFrappeGetDocList } from "frappe-react-sdk";
+import { Skeleton } from "@/components/ui/skeleton";
+import { TaskTable } from "./EstimationsReviewTable";
+
+export const BoqBcsReviewTable = () => {
+    // role based access
+    const role = localStorage.getItem("role");
+    const isEstimationLead = role === "Nirmaan Estimations lead Profile" || role === "Nirmaan Estimations Lead Profile" || role === "Nirmaan Admin User Profile";
+    const isEstimationsTeam = role === "Nirmaan Estimations User Profile" || role === "Nirmaan Estimates User Profile" || isEstimationLead;
+    const userEmail = localStorage.getItem("userId") || "";
+
+    const { data: estimations, isLoading: estimationsLoading } = useFrappeGetDocList<any>(
+        "CRM Project Estimation",
+        {
+          fields: ["name", "parent_project", "title", "package_name", "document_type", "value", "link", "status", "sub_status", "deadline", "remarks", "assigned_to", "creation"],
+          limit: 0,
+        },
+        "home-boqbcs-review-estimations"
+    );
+
+    const { data: projects, isLoading: projectsLoading } = useFrappeGetDocList<any>(
+        "CRM BOQ",
+        {
+          fields: ["name", "boq_name"],
+          limit: 0,
+        },
+        "home-boqbcs-review-projects"
+    );
+
+    const { data: teamUsers, isLoading: usersLoading } = useFrappeGetDocList<any>(
+        "CRM Users",
+        {
+          fields: ["name", "full_name"],
+          limit: 0,
+        },
+        "home-boqbcs-review-users"
+    );
+
+    const projectMap = useMemo(() => {
+        const map = new Map<string, any>();
+        (projects || []).forEach((project: any) => {
+          map.set(project.name, project);
+        });
+        return map;
+      }, [projects]);
+    
+    const userNameMap = useMemo(() => {
+        const map = new Map<string, string>();
+        (teamUsers || []).forEach((user: any) => {
+            map.set(user.name, user.full_name || user.name);
+        });
+        return map;
+    }, [teamUsers]);
+
+    const targetStatuses = new Set(["in progress", "in-progress", "partial boq submitted", "revision pending", "hold"]);
+    const normalizeStatus = (status: string) => (status||"").toLowerCase().replace(/[_-]+/g, " ").replace(/\s+/g, " ").trim();
+
+    const pendingWipEstimations = useMemo(() => {
+        const items = (estimations || []).filter((item: any) => targetStatuses.has(normalizeStatus(item.status)));
+        // Admin and leads see all tasks
+        if (isEstimationLead) return items;
+        // Regular estimation users see only their own assigned tasks
+        return items.filter((item: any) => {
+            const assignee = (item.assigned_to || "").trim();
+            return assignee === userEmail;
+        });
+    }, [estimations, isEstimationLead, userEmail]);
+
+    if (estimationsLoading || projectsLoading || usersLoading) {
+        return (
+          <div className="space-y-3 rounded-lg border border-gray-200 bg-white p-4">
+            <Skeleton className="h-8 w-48" />
+            <Skeleton className="h-10 w-full" />
+            <Skeleton className="h-10 w-full" />
+            <Skeleton className="h-10 w-full" />
+          </div>
+        );
+      }
+
+    return (
+        <div className="space-y-4">
+           <TaskTable 
+             items={pendingWipEstimations}
+             showProjectName={true}
+             projectMap={projectMap}
+             userNameMap={userNameMap}
+             isEstimationsTeam={isEstimationsTeam}
+             title="Pending Tasks"
+             maxHeightClass="max-h-[calc(90vh-200px)]"
+           />
+        </div>
+    )
+}

--- a/crm/src/pages/Home/components/EstimationsReviewTable.tsx
+++ b/crm/src/pages/Home/components/EstimationsReviewTable.tsx
@@ -5,7 +5,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { Button } from "@/components/ui/button";
 import { useDialogStore } from "@/store/dialogStore";
 import { cn } from "@/lib/utils";
-import { formatDateWithOrdinal } from "@/utils/FormatDate";
+
 import { StandaloneFacetedFilter } from "@/components/table/standalone-faceted-filter";
 import { StandaloneDateFilter, DateFilterValue, matchDateFilter } from "@/components/table/standalone-date-filter";
 import { BoqBcsTaskExport } from "../../BOQS/components/BoqBcsTaskExport";
@@ -148,6 +148,19 @@ const isOverdue = (deadline?: string, status?: string) => {
   return dueDate.getTime() < today.getTime();
 };
 
+export const isDueToday = (deadline?: string, status?: string) => {
+  if (!deadline || isCompletedStatus(status)) return false;
+
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+
+  const dueDate = new Date(deadline);
+  if (Number.isNaN(dueDate.getTime())) return false;
+
+  dueDate.setHours(0, 0, 0, 0);
+  return dueDate.getTime() === today.getTime();
+};
+
 const getStatusPillClass = (status?: string) => {
   const normalized = normalizeStatus(status);
 
@@ -204,13 +217,14 @@ const CountButton = ({
   );
 };
 
-const TaskTable = ({
+export const TaskTable = ({
   items,
   showProjectName,
   projectMap,
   userNameMap,
   isEstimationsTeam,
-  title
+  title,
+  maxHeightClass = "max-h-[400px]"
 }: {
   items: CRMProjectEstimation[];
   showProjectName: boolean;
@@ -218,6 +232,7 @@ const TaskTable = ({
   userNameMap: Map<string, string>;
   isEstimationsTeam?: boolean;
   title?: string;
+  maxHeightClass?: string;
 }) => {
   const [projectFilter, setProjectFilter] = useState<string[]>([]);
   const [taskNameFilter, setTaskNameFilter] = useState<string[]>([]);
@@ -283,7 +298,7 @@ const TaskTable = ({
           />
         </div>
       )}
-      <div className="overflow-auto max-h-[400px] relative">
+      <div className={cn("overflow-auto relative", maxHeightClass)}>
         <table className="w-full min-w-[980px] text-sm">
           <thead className="bg-gray-50 text-xs uppercase tracking-wide text-gray-500 sticky top-0 z-10">
             <tr>
@@ -337,8 +352,11 @@ const TaskTable = ({
             </tr>
           </thead>
           <tbody className="divide-y divide-gray-100">
-            {filteredItems.map((item) => (
-              <tr key={item.name} className="align-top">
+            {filteredItems.map((item) => {
+              const overdue = isOverdue(item.deadline, item.status);
+              const dueToday = isDueToday(item.deadline, item.status);
+              return (
+              <tr key={item.name} className={cn("align-top", overdue ? "bg-red-50 hover:bg-red-100/50" : dueToday ? "bg-yellow-50 hover:bg-yellow-100/50" : "hover:bg-gray-50")}>
                 {showProjectName && (
                   <td className="px-3 py-2 text-sm text-gray-900">
                     {projectMap.get(item.parent_project || "")?.boq_name || item.parent_project || "--"}
@@ -351,7 +369,7 @@ const TaskTable = ({
                 </td>
                 <td className="px-3 py-2 text-sm text-gray-700">{item.remarks || "--"}</td>
                 <td className="px-3 py-2 text-sm text-gray-700">
-                  {item.deadline ? formatDateWithOrdinal(item.deadline) : "--"}
+                  {item.deadline ? new Date(item.deadline).toLocaleDateString("en-GB", { day: "numeric", month: "short", year: "numeric" }) : "--"}
                 </td>
                 <td className="px-3 py-2">
                   {item.link ? (
@@ -389,7 +407,14 @@ const TaskTable = ({
                   </td>
                 )}
               </tr>
-            ))}
+            )})}
+            {filteredItems.length === 0 && (
+              <tr>
+                <td colSpan={showProjectName ? 10 : 9} className="px-3 py-8 text-center text-sm text-gray-400">
+                  No matching records found.
+                </td>
+              </tr>
+            )}
           </tbody>
         </table>
       </div>
@@ -601,16 +626,6 @@ export const EstimationsReviewTable = () => {
       }
     });
 
-    const teamRow: SummaryRow = {
-      key: TEAM_KEY,
-      label: "Estimations Team",
-      assignee: null,
-      activeProjects: new Set(filteredEstimations.map((item) => item.parent_project).filter(Boolean)).size,
-      totalTasks: filteredEstimations.length,
-      overdue: filteredEstimations.filter((item) => isOverdue(item.deadline, item.status)).length,
-      isTeam: true,
-    };
-
     const rows: SummaryRow[] = [...accumulators.values()]
       .filter((item) => item.key !== UNASSIGNED_KEY)
       .map((item) => ({
@@ -635,7 +650,7 @@ export const EstimationsReviewTable = () => {
       });
     }
 
-    return [teamRow, ...rows];
+    return [...rows];
   }, [filteredEstimations, teamUsers, userNameMap]);
 
   // For non-lead users, filter summary rows to only show their own row + unassigned

--- a/crm/src/pages/Tasks/NewEstimationTaskForm.tsx
+++ b/crm/src/pages/Tasks/NewEstimationTaskForm.tsx
@@ -125,11 +125,11 @@ export const NewEstimationTaskForm = ({ onSuccess }: NewEstimationTaskFormProps)
                           />
                         )}
                 <FormField
-                    name="boq"
+                    name="Projec"
                     control={form.control}
                     render={({ field }) => (
                         <FormItem>
-                            <FormLabel>BOQ<sup>*</sup></FormLabel>
+                            <FormLabel>Project<sup>*</sup></FormLabel>
                             <FormControl>
                                 {boqIdFromContext ? (
                                     <Input value={boqIdFromContext} disabled />
@@ -139,7 +139,7 @@ export const NewEstimationTaskForm = ({ onSuccess }: NewEstimationTaskFormProps)
                                         isLoading={boqsLoading}
                                         value={boqOptions.find(b => b.value === field.value)}
                                         onChange={val => field.onChange(val?.value)}
-                                        placeholder="Select a BOQ"
+                                        placeholder="Select a Project"
                                         menuPosition={'auto'}
                                     />
                                 )}

--- a/crm/src/pages/Tasks/NewTaskForm.tsx
+++ b/crm/src/pages/Tasks/NewTaskForm.tsx
@@ -197,8 +197,8 @@ export const NewTaskForm = ({ onSuccess }: NewTaskFormProps) => {
           )}
         </FormControl><FormMessage /></FormItem>)} />
 
-        <FormField name="boq" control={form.control} render={({ field }) => (<FormItem><FormLabel>BOQ</FormLabel><FormControl>
-          <ReactSelect options={boqOptions} isLoading={boqsLoading} value={boqOptions.find(b => b.value === field.value)} onChange={val => field.onChange(val?.value)} menuPosition={'auto'} placeholder="Select BOQ (Optional)" isClearable isDisabled={!(selectedContactByUser || contactIdFromContext)} />
+        <FormField name="boq" control={form.control} render={({ field }) => (<FormItem><FormLabel>Project</FormLabel><FormControl>
+          <ReactSelect options={boqOptions} isLoading={boqsLoading} value={boqOptions.find(b => b.value === field.value)} onChange={val => field.onChange(val?.value)} menuPosition={'auto'} placeholder="Select Project (Optional)" isClearable isDisabled={!(selectedContactByUser || contactIdFromContext)} />
         </FormControl><FormMessage /></FormItem>)} />
 
         <FormField name="remarks" control={form.control} render={({ field }) => (<FormItem><FormLabel>Remarks<sup>*</sup></FormLabel><FormControl><Textarea placeholder="e.g. Discuss Q3 results." {...field} /></FormControl><FormMessage /></FormItem>)} />

--- a/crm/src/types/NirmaanCRM/CRMBOQ.ts
+++ b/crm/src/types/NirmaanCRM/CRMBOQ.ts
@@ -20,6 +20,8 @@ export interface CRMBOQ{
 	boq_size?: string
 	/**	BOQ Type : Data	*/
 	boq_type?: string
+	/**	Create BCS : Check	*/
+	create_bcs?: 0 | 1
 	/**	BOQ Value : Data	*/
 	boq_value?: string
 	/**	BOQ Submission Date : Date	*/

--- a/nirmaan_crm/nirmaan_crm/doctype/crm_boq/crm_boq.json
+++ b/nirmaan_crm/nirmaan_crm/doctype/crm_boq/crm_boq.json
@@ -14,6 +14,7 @@
   "boq_name",
   "boq_size",
   "boq_type",
+  "create_bcs",
   "boq_value",
   "boq_submission_date",
   "boq_link",
@@ -67,6 +68,12 @@
    "label": "BOQ Type"
   },
   {
+   "default": "0",
+   "fieldname": "create_bcs",
+   "fieldtype": "Check",
+   "label": "Create BCS"
+  },
+  {
    "fieldname": "boq_value",
    "fieldtype": "Data",
    "label": "BOQ Value"
@@ -84,7 +91,8 @@
   {
    "fieldname": "city",
    "fieldtype": "Data",
-   "label": "City"
+   "label": "City",
+   "reqd": 1
   },
   {
    "fieldname": "remarks",

--- a/nirmaan_crm/nirmaan_crm/doctype/crm_boq/crm_boq.py
+++ b/nirmaan_crm/nirmaan_crm/doctype/crm_boq/crm_boq.py
@@ -8,6 +8,8 @@ from frappe.utils import cint
 
 class CRMBOQ(Document):
 	def validate(self):
+		self._lock_create_bcs_once_enabled()
+
 		if self.boq_status in ["Won", "Lost"]:
 			self.deal_status = "Cold"
 
@@ -62,7 +64,12 @@ class CRMBOQ(Document):
 			if not isinstance(packages, list):
 				packages = [packages]
 		except Exception:
-			packages = [raw_packages]
+			cleaned_raw = str(raw_packages or "").strip()
+			# Backward compatibility for legacy values stored as comma-separated text.
+			if "," in cleaned_raw:
+				packages = [item.strip() for item in cleaned_raw.split(",")]
+			else:
+				packages = [cleaned_raw]
 
 		normalized_packages = []
 		for package_name in packages:
@@ -96,3 +103,20 @@ class CRMBOQ(Document):
 			}
 		)
 		doc.insert(ignore_permissions=True)
+
+	def _lock_create_bcs_once_enabled(self):
+		if self.is_new():
+			return
+
+		existing_toggle_value = cint(
+			frappe.db.get_value(self.doctype, self.name, "create_bcs") or 0
+		)
+		has_existing_bcs_rows = bool(
+			frappe.db.exists(
+				"CRM Project Estimation",
+				{"parent_project": self.name, "document_type": "BCS"},
+			)
+		)
+
+		if existing_toggle_value == 1 or has_existing_bcs_rows:
+			self.create_bcs = 1

--- a/nirmaan_crm/nirmaan_crm/doctype/crm_boq/crm_boq.py
+++ b/nirmaan_crm/nirmaan_crm/doctype/crm_boq/crm_boq.py
@@ -4,6 +4,7 @@
 import frappe
 import json
 from frappe.model.document import Document
+from frappe.utils import cint
 
 class CRMBOQ(Document):
 	def validate(self):
@@ -11,6 +12,9 @@ class CRMBOQ(Document):
 			self.deal_status = "Cold"
 
 	def before_insert(self):
+		if not (getattr(self, "city", None) or "").strip():
+			frappe.throw("City is required.")
+
 		user = frappe.session.user
 		if user == "Administrator":
 			pass
@@ -29,44 +33,66 @@ class CRMBOQ(Document):
 				pass
 
 	def on_update(self):
-		if getattr(self, "boq_type", None):
-			try:
-				packages = json.loads(self.boq_type)
-				if not isinstance(packages, list):
-					packages = [self.boq_type]
-			except Exception:
-				packages = [self.boq_type] if self.boq_type else []
+		packages = self._get_selected_packages()
+		if not packages:
+			return
 
-			for pkg in packages:
-				# Route to the package's specific lead, if configured in CRM BOQ Package
-				# If the package is custom (not found) or has no lead configured, it will be None
-				package_lead = frappe.db.get_value("CRM BOQ Package", pkg, "assigned_lead")
-				pkg_assigned_to = package_lead if package_lead else None
+		should_create_bcs = cint(getattr(self, "create_bcs", 0)) == 1
 
-				# Check if BOQ exists for this package
-				if not frappe.db.exists("CRM Project Estimation", {"parent_project": self.name, "document_type": "BOQ", "package_name": pkg}):
-					doc = frappe.get_doc({
-						"doctype": "CRM Project Estimation",
-						"title": f"{self.name} - {pkg} BOQ",
-						"parent_project": self.name,
-						"document_type": "BOQ",
-						"package_name": pkg,
-						"deadline": getattr(self, "boq_submission_date", None),
-						"assigned_to": pkg_assigned_to,
-						"status": "New"
-					})
-					doc.insert(ignore_permissions=True)
-				
-				# Check if BCS exists for this package
-				if not frappe.db.exists("CRM Project Estimation", {"parent_project": self.name, "document_type": "BCS", "package_name": pkg}):
-					doc = frappe.get_doc({
-						"doctype": "CRM Project Estimation",
-						"title": f"{self.name} - {pkg} BCS",
-						"parent_project": self.name,
-						"document_type": "BCS",
-						"package_name": pkg,
-						"deadline": getattr(self, "boq_submission_date", None),
-						"assigned_to": pkg_assigned_to,
-						"status": "New"
-					})
-					doc.insert(ignore_permissions=True)
+		for package_name in packages:
+			# Route to the package's specific lead, if configured in CRM BOQ Package.
+			# If the package is custom (not found) or has no lead configured, it remains unassigned.
+			package_lead = frappe.db.get_value("CRM BOQ Package", package_name, "assigned_lead")
+			assigned_to = package_lead if package_lead else None
+
+			# BOQ estimation rows are always created for package-based projects.
+			self._create_project_estimation_if_missing(package_name, "BOQ", assigned_to)
+
+			# BCS rows are created only when explicitly enabled from project create/edit flow.
+			if should_create_bcs:
+				self._create_project_estimation_if_missing(package_name, "BCS", assigned_to)
+
+	def _get_selected_packages(self):
+		raw_packages = getattr(self, "boq_type", None)
+		if not raw_packages:
+			return []
+
+		try:
+			packages = json.loads(raw_packages)
+			if not isinstance(packages, list):
+				packages = [packages]
+		except Exception:
+			packages = [raw_packages]
+
+		normalized_packages = []
+		for package_name in packages:
+			name = (str(package_name or "")).strip()
+			if name and name not in normalized_packages:
+				normalized_packages.append(name)
+
+		return normalized_packages
+
+	def _create_project_estimation_if_missing(self, package_name, document_type, assigned_to=None):
+		if frappe.db.exists(
+			"CRM Project Estimation",
+			{
+				"parent_project": self.name,
+				"document_type": document_type,
+				"package_name": package_name,
+			},
+		):
+			return
+
+		doc = frappe.get_doc(
+			{
+				"doctype": "CRM Project Estimation",
+				"title": f"{self.name} - {package_name} {document_type}",
+				"parent_project": self.name,
+				"document_type": document_type,
+				"package_name": package_name,
+				"deadline": getattr(self, "boq_submission_date", None),
+				"assigned_to": assigned_to,
+				"status": "New",
+			}
+		)
+		doc.insert(ignore_permissions=True)

--- a/nirmaan_crm/patches/v0_0/migrate_legacy_boq_projects_to_estimations.py
+++ b/nirmaan_crm/patches/v0_0/migrate_legacy_boq_projects_to_estimations.py
@@ -247,6 +247,7 @@ def execute():
         "boq_rows_created": 0,
         "bcs_rows_created": 0,
         "project_statuses_updated": 0,
+        "project_packages_normalized": 0,
     }
 
     for index, project_name in enumerate(project_names, start=1):
@@ -254,6 +255,16 @@ def execute():
         project_boq_value = _coerce_float(getattr(project_doc, "boq_value", None))
 
         parsed_packages = parse_project_packages(getattr(project_doc, "boq_type", None))
+        normalized_boq_type = json.dumps(parsed_packages) if parsed_packages else "[]"
+        if _clean_text(getattr(project_doc, "boq_type", None)) != normalized_boq_type:
+            frappe.db.set_value(
+                "CRM BOQ",
+                project_doc.name,
+                "boq_type",
+                normalized_boq_type,
+                update_modified=False,
+            )
+            summary["project_packages_normalized"] += 1
 
         if not parsed_packages:
             # Rule 3: No package in old data -> use Legacy BOQ/BCS.
@@ -309,3 +320,4 @@ def execute():
     print(f"BOQ rows created: {summary['boq_rows_created']}")
     print(f"BCS rows created: {summary['bcs_rows_created']}")
     print(f"Project statuses updated: {summary['project_statuses_updated']}")
+    print(f"Project packages normalized: {summary['project_packages_normalized']}")

--- a/nirmaan_crm/patches/v0_0/migrate_legacy_boq_projects_to_estimations.py
+++ b/nirmaan_crm/patches/v0_0/migrate_legacy_boq_projects_to_estimations.py
@@ -23,6 +23,15 @@ DETAILED_TO_PROJECT_STATUS = {
     "COMPLETED": "In-Progress",
 }
 
+PROJECT_LEVEL_STATUSES_FOR_BOQ_SUBMITTED = {
+    "LOST",
+    "DROPPED",
+    "WON",
+    "HOLD",
+    "ON HOLD",
+    "NEGOTIATION",
+}
+
 KNOWN_PACKAGE_LABELS = [
     ("HVAC VRF-DX", "HVAC VRF-DX"),
     ("HVAC DUCTING", "HVAC Ducting"),
@@ -86,6 +95,10 @@ def normalize_boq_estimation_status(value):
         return "New"
 
     upper_value = cleaned.upper()
+    if upper_value in PROJECT_LEVEL_STATUSES_FOR_BOQ_SUBMITTED:
+        # These are project-level outcomes; migrated BOQ rows should stay at
+        # BOQ-level status.
+        return "BOQ Submitted"
     if upper_value in PROJECT_STATUS_ALIASES:
         return PROJECT_STATUS_ALIASES[upper_value]
 
@@ -196,7 +209,8 @@ def _create_estimation_if_missing(project_doc, package_name, document_type, boq_
         payload["value"] = boq_value_for_package
         payload["link"] = _clean_text(getattr(project_doc, "boq_link", None)) or None
     else:
-        payload["status"] = normalize_bcs_status(getattr(project_doc, "bcs_status", None))
+        # Migration rule: all migrated BCS rows should start in Pending.
+        payload["status"] = "Pending"
         payload["sub_status"] = None
         payload["value"] = None
         payload["link"] = None
@@ -237,14 +251,36 @@ def execute():
 
     for index, project_name in enumerate(project_names, start=1):
         project_doc = frappe.get_doc("CRM BOQ", project_name)
-        # Migration decision: force all legacy projects to a single Legacy package,
-        # even when historical boq_type has package text.
-        package_names = [LEGACY_PACKAGE_NAME]
-        summary["projects_with_legacy_package"] += 1
-
         project_boq_value = _coerce_float(getattr(project_doc, "boq_value", None))
-        for package_index, package_name in enumerate(package_names):
-            boq_value_for_package = project_boq_value if package_index == 0 else 0.0
+
+        parsed_packages = parse_project_packages(getattr(project_doc, "boq_type", None))
+
+        if not parsed_packages:
+            # Rule 3: No package in old data -> use Legacy BOQ/BCS.
+            package_names = [LEGACY_PACKAGE_NAME]
+        elif len(parsed_packages) == 1:
+            # Rule 1: Single package in old data -> only that package BOQ/BCS.
+            package_names = parsed_packages
+        else:
+            # Rule 2: Multiple packages in old data ->
+            # create Legacy BOQ/BCS plus per-package BOQ/BCS.
+            # Keep value in Legacy BOQ only; package BOQs get empty value.
+            package_names = [LEGACY_PACKAGE_NAME] + [
+                pkg for pkg in parsed_packages if _clean_text(pkg).lower() != LEGACY_PACKAGE_NAME.lower()
+            ]
+
+        package_names = _dedupe_preserve_order(package_names)
+        if LEGACY_PACKAGE_NAME in package_names:
+            summary["projects_with_legacy_package"] += 1
+
+        for package_name in package_names:
+            if package_name == LEGACY_PACKAGE_NAME:
+                boq_value_for_package = project_boq_value
+            elif len(parsed_packages) == 1:
+                boq_value_for_package = project_boq_value
+            else:
+                boq_value_for_package = None
+
             if _create_estimation_if_missing(project_doc, package_name, "BOQ", boq_value_for_package=boq_value_for_package):
                 summary["boq_rows_created"] += 1
             if _create_estimation_if_missing(project_doc, package_name, "BCS"):


### PR DESCRIPTION
… and UI cleanup

- Removed top status tabs (ALL / NEW / IN-PROGRESS); retained table-level filters
- Project creation now always creates BOQ; BCS optional via `create_bcs`
- Added optional BCS creation on project edit for newly added packages
- Prevented duplicate BCS creation (only for packages without existing BCS)
- Enabled package addition for legacy projects (removed legacy lock)
- Removed ordinal suffixes from date fields (st, nd, rd, th)
- Removed TYPE and PACKAGE columns from BOQ/BCS subtable UI
- Enforced City as mandatory (frontend + backend + doctype)

Migration:
- No package → legacy BOQ/BCS
- One package → only package BOQ/BCS (no legacy)
- Multiple packages → legacy + package BOQ/BCS (value in legacy BOQ)

Status mapping:
- Project statuses (Lost/Dropped/Won/Hold/Negotiation) → BOQ Submitted
- Old BCS status → Pending

Fix:
- Resolved BOQ/BCS table overlap by disabling virtualization for expandable rows