### PR TITLE
 feat: add project navigation links, package removal with cleanup, an…

### DIFF
--- a/crm/src/constants/boqZodValidation.ts
+++ b/crm/src/constants/boqZodValidation.ts
@@ -188,6 +188,13 @@ export const boqDetailsSchema = z.object({
       path: ['company'],
     });
   }
+  if (!data.boq_type || data.boq_type.length === 0) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "At least one package is required.",
+      path: ['boq_type'],
+    });
+  }
   if (data.city === "Others" && (!data.other_city || data.other_city.trim() === "")) {
     ctx.addIssue({
       code: z.ZodIssueCode.custom,

--- a/crm/src/constants/dropdownData.ts
+++ b/crm/src/constants/dropdownData.ts
@@ -87,10 +87,11 @@ export const LocationOptions = [
 // ... (your existing LocationOptions, TeamSizeOptions, etc.)
 
 export const CompanyProgressPriorityOptions = [
-    { label: "Meet Every Week", value: "Meet Every Week" },
+  { label: "Meet Every Week", value: "Meet Every Week" },
   { label: "Meet Once Every 2 Weeks", value: "Meet Once Every 2 Weeks" },
   { label: "Meet Once a Month", value: "Meet Once a Month" },
   { label: "Hold", value: "Hold" },
+  { label: "Future Prospect", value: "Future Prospect" },
 ];
 
 export const TeamSizeOptions = [

--- a/crm/src/pages/BOQS/BOQ.tsx
+++ b/crm/src/pages/BOQS/BOQ.tsx
@@ -191,7 +191,10 @@ const ProjectOverviewCard = ({ boq, contact, company, estimations }: { boq: CRMB
         .filter((est) => (est.document_type || '').toUpperCase() === 'BCS')
         .reduce((sum, est) => sum + (Number(est.value) || 0), 0);
 
-    const totalValue = boqTotalFromRows > 0 ? boqTotalFromRows : (Number(boq?.boq_value) || 0);
+    // If estimation rows exist, always use the aggregated sum (even if zero);
+    // fall back to legacy boq_value only when there are no BOQ estimation rows at all.
+    const hasBoqEstimations = (estimations || []).some((est) => (est.document_type || '').toUpperCase() === 'BOQ');
+    const totalValue = hasBoqEstimations ? boqTotalFromRows : (Number(boq?.boq_value) || 0);
     const hasBcsValue = bcsTotalFromRows > 0;
     const profitValue = hasBcsValue ? totalValue - bcsTotalFromRows : 0;
     const profitPercent = hasBcsValue && totalValue > 0 ? (profitValue / totalValue) * 100 : 0;

--- a/crm/src/pages/BOQS/EditBoqForm.tsx
+++ b/crm/src/pages/BOQS/EditBoqForm.tsx
@@ -101,6 +101,22 @@ export const EditBoqForm = ({ onSuccess }: EditBoqFormProps) => {
     return packages;
   }, [estimations]);
 
+  const packagesWithAnyTasks = useMemo(() => {
+    const packages = new Set<string>();
+    (estimations || []).forEach((est) => {
+      const pkg = (est.package_name || "").trim();
+      if (pkg) packages.add(pkg);
+    });
+    return Array.from(packages);
+  }, [estimations]);
+
+  // Detect if this project has legacy tasks (migrated from old data)
+  const hasLegacyTasks = useMemo(() => {
+    return (estimations || []).some(
+      (est) => (est.package_name || "").trim() === "Legacy"
+    );
+  }, [estimations]);
+
   const pendingBcsPackages = useMemo(() => {
     return (selectedPackages || [])
       .map((pkg: string) => (pkg || "").trim())
@@ -131,11 +147,17 @@ export const EditBoqForm = ({ onSuccess }: EditBoqFormProps) => {
       const initialCityValue = isStandardCity ? boqData.city : "Others";
       const initialOtherCityValue = isStandardCity ? "" : boqData.city || "";
 
+      // Build packages list, injecting "Legacy" if legacy tasks exist
+      const parsedPackages = parsePackages(boqData.boq_type);
+      if (hasLegacyTasks && !parsedPackages.includes("Legacy")) {
+        parsedPackages.unshift("Legacy");
+      }
+
       form.reset({
         ...boqData,
         city: initialCityValue || "",
         other_city: initialOtherCityValue,
-        boq_type: parsePackages(boqData.boq_type),
+        boq_type: parsedPackages,
         create_bcs: boqData.create_bcs === 1,
         boq_value: Number(boqData.boq_value) || 0,
         boq_size: Number(boqData.boq_size) || 0,
@@ -147,7 +169,7 @@ export const EditBoqForm = ({ onSuccess }: EditBoqFormProps) => {
         boq_submission_date: boqData.boq_submission_date || ""
       });
     }
-  }, [boqData, form]);
+  }, [boqData, form, hasLegacyTasks]);
 
   useEffect(() => {
     if (isCreateBcsLocked && !form.getValues("create_bcs")) {
@@ -338,6 +360,7 @@ export const EditBoqForm = ({ onSuccess }: EditBoqFormProps) => {
                       value={field.value || []}
                       onChange={field.onChange}
                       placeholder="Select packages..."
+                      packagesWithTasks={packagesWithAnyTasks}
                     />
                   </FormControl>
                   <FormMessage />

--- a/crm/src/pages/BOQS/components/PackagesMultiSelect.tsx
+++ b/crm/src/pages/BOQS/components/PackagesMultiSelect.tsx
@@ -29,15 +29,18 @@ interface PackagesMultiSelectProps {
   onChange: (packages: string[]) => void;
   placeholder?: string;
   disabled?: boolean;
+  packagesWithTasks?: string[];
 }
-
 export function PackagesMultiSelect({
   value,
   onChange,
   placeholder = "Select packages...",
   disabled = false,
+  packagesWithTasks = [],
 }: PackagesMultiSelectProps) {
   const [isDialogOpen, setIsDialogOpen] = useState(false);
+  const [isConfirmOpen, setIsConfirmOpen] = useState(false);
+  const [pendingValue, setPendingValue] = useState<string[] | null>(null);
   const [customInput, setCustomInput] = useState("");
 
   // Convert string array to react-select format
@@ -84,12 +87,35 @@ export function PackagesMultiSelect({
       return;
     }
 
-    // Filter out "Others" from selected values (should never be in there, but just in case)
+    // Filter out "Others" from selected values
     const filteredValues = newValue
       .filter((opt) => opt.value !== OTHERS_OPTION.value)
       .map((opt) => opt.value);
 
+    // Check if any removed packages have associated tasks
+    const removedPackages = value.filter(v => !filteredValues.includes(v));
+    const hasTasksToRemove = removedPackages.some(pkg => packagesWithTasks.includes(pkg));
+
+    if (hasTasksToRemove && (actionMeta.action === "remove-value" || actionMeta.action === "pop-value" || actionMeta.action === "clear")) {
+      setPendingValue(filteredValues);
+      setIsConfirmOpen(true);
+      return;
+    }
+
     onChange(filteredValues);
+  };
+
+  const handleConfirmRemoval = () => {
+    if (pendingValue !== null) {
+      onChange(pendingValue);
+    }
+    setPendingValue(null);
+    setIsConfirmOpen(false);
+  };
+
+  const handleCancelRemoval = () => {
+    setPendingValue(null);
+    setIsConfirmOpen(false);
   };
 
   const handleAddCustomPackage = () => {
@@ -208,6 +234,32 @@ export function PackagesMultiSelect({
               disabled={!customInput.trim()}
             >
               Add Package
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+      {/* Removal Confirmation Dialog */}
+      <Dialog open={isConfirmOpen} onOpenChange={setIsConfirmOpen}>
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>Remove Package?</DialogTitle>
+            <DialogDescription className="py-2">
+              Are you sure you want to remove this package? <br />
+              <span className="font-semibold text-destructive">
+                This action will also delete all tasks associated with this package.
+              </span>
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter className="mt-4">
+            <Button type="button" variant="outline" onClick={handleCancelRemoval}>
+              Cancel
+            </Button>
+            <Button
+              type="button"
+              variant="destructive"
+              onClick={handleConfirmRemoval}
+            >
+              Confirm
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/crm/src/pages/Companies/CompanyDetailsCard.tsx
+++ b/crm/src/pages/Companies/CompanyDetailsCard.tsx
@@ -48,7 +48,7 @@ export const CompanyDetailsCard = ({ company, totalProjects, totalContacts, acti
                     <div>
                         {/* <p className="text-xs text-muted-foreground">Company Name</p> */}
                         <div className="flex items-center gap-2">
-                            <p className="text-sm text-muted-foreground">BOQ Company</p>
+                            <p className="text-sm text-muted-foreground">Company Name</p>
 
                             <Button
                                 variant="ghost" // Use a ghost variant for a subtle, icon-only button
@@ -82,11 +82,11 @@ export const CompanyDetailsCard = ({ company, totalProjects, totalContacts, acti
                         <p className="font-bold text-sm">{formatDateWithOrdinal(company.last_meeting)}</p> {/* This is static for now */}
                     </div>
                     <div>
-                        <p className="text-xs text-muted-foreground">Total BOQs</p>
+                        <p className="text-xs text-muted-foreground">Total Projects</p>
                         <p className="font-bold text-lg">{String(totalProjects).padStart(2, '0')}</p>
                     </div>
                     <div className="text-right">
-                        <p className="text-xs text-muted-foreground">Active BOQs</p>
+                        <p className="text-xs text-muted-foreground">Active Projects</p>
                         <p className="font-bold text-lg">{activeProjects}</p> {/* This is static for now */}
                     </div>
                     <div>

--- a/crm/src/pages/Companies/DynamicCompanyStats.tsx
+++ b/crm/src/pages/Companies/DynamicCompanyStats.tsx
@@ -98,8 +98,8 @@ export const DynamicCompanyStats = ({ companyId }: DynamicCompanyStatsProps) => 
         { title: "Follow Up Meetings", data: statsData?.followUpMeetings },
 
         // { title: "Pending Tasks", data: statsData?.pendingTasks },
-        { title: "BOQ Received", data: statsData?.boqReceived },
-        { title: "BOQ Sent", data: statsData?.boqSent },
+        { title: "Projects Received", data: statsData?.boqReceived },
+        { title: "Projects Sent", data: statsData?.boqSent },
     ];
 
     return (

--- a/crm/src/pages/Companies/components/CompanyProgressCard.tsx
+++ b/crm/src/pages/Companies/components/CompanyProgressCard.tsx
@@ -37,7 +37,7 @@ export const CompanyProgressCard = ({ company }: CompanyProgressCardProps) => {
             </span>
         </p>
         <p className="text-sm text-muted-foreground">
-            Expected BOQs in 15 days: <span className="font-medium">{company.expected_boq_count ?? 'N/A'}</span>
+            Expected Projects in 15 days: <span className="font-medium">{company.expected_boq_count ?? 'N/A'}</span>
         </p>
     </div>
 

--- a/crm/src/pages/Companies/components/cells/PriorityBadge.tsx
+++ b/crm/src/pages/Companies/components/cells/PriorityBadge.tsx
@@ -29,6 +29,12 @@ const PRIORITY_CONFIG = [
     styles: 'bg-sky-50 text-sky-700 border-sky-200 dark:bg-sky-900/30 dark:text-sky-300 dark:border-sky-800',
   },
   {
+    // "Future prospect"
+    match: (p: string) => p.includes('future'),
+    label: 'Future',
+    styles: 'bg-green-50 text-green-700 border-green-200 dark:bg-green-900/30 dark:text-green-300 dark:border-green-800',
+  },
+  {
     // "Hold" - paused
     match: (p: string) => p.includes('hold'),
     label: 'Hold',

--- a/crm/src/pages/Home/EstimationsHomePage.tsx
+++ b/crm/src/pages/Home/EstimationsHomePage.tsx
@@ -494,9 +494,9 @@ export const AllBOQs = () => {
             accessorKey: "boq_name",
             meta: { title: "Project Name", filterVariant: 'select', enableSorting: true, filterOptions: projectNamesOptions },
             cell: ({ row }) => (
-                <span className="text-primary font-semibold hover:underline text-left">
+                <Link to={`/boqs/boq?id=${row.original.name}`} className="text-primary font-semibold hover:underline text-left">
                     {row.original.boq_name}
-                </span>
+                </Link>
             ),
            
         },
@@ -627,9 +627,9 @@ export const AllBOQs = () => {
     const renderBoqMobileRow = (row: Row<BOQ>) => (
         <div className="flex justify-between items-start p-3 border rounded-lg">
             <div className="flex flex-col text-left">
-                <p className="text-primary font-semibold hover:underline text-left">
+                <Link to={`/boqs/boq?id=${row.original.name}`} className="text-primary font-semibold hover:underline text-left">
                     {row.original.boq_name}
-                </p>
+                </Link>
                 <p className="text-sm text-muted-foreground">{row.original.company || '--'}</p>
                 <p className="text-xs text-muted-foreground">Created By: {row.original.owner} </p>
                 <p className="text-xs text-muted-foreground mt-1">

--- a/crm/src/pages/Home/PendingTasks.tsx
+++ b/crm/src/pages/Home/PendingTasks.tsx
@@ -15,6 +15,7 @@ import {
     DropdownMenuTrigger
 } from "@/components/ui/dropdown-menu"; // 3. Import Dropdown components
 // ... other imports
+import { Link } from "react-router-dom";
 import { TaskStatusIcon } from "@/components/ui/TaskStatusIcon";
 
 type FilterOption = 'last 7 days' | 'Today' | 'All';
@@ -28,7 +29,7 @@ const PendingTaskRow = ({ task }: { task: EnrichedCRMTask }) => {
                     <div className="flex">
                         <TaskStatusIcon status={task.status} className="mr-1 flex-shrink-0" />
                         {task.task_profile==="Sales"?(
-                        <div> 
+                            <div>
                             
                             <span className="font-semibold">{task?.type}</span> with <span className="font-semibold">{task?.first_name}</span>{" "} from {task?.company_name} {" "}
                             <p className="text-xs inline-block text-muted-foreground p-0 m-0">
@@ -37,14 +38,19 @@ const PendingTaskRow = ({ task }: { task: EnrichedCRMTask }) => {
                         </div>
                         ):(
                             <div>
-                            
-                            <span className="font-semibold">{task?.type}</span> for <span className="font-semibold"> {task?.boq} {" "}</span>
-                            <p className="text-xs inline-block text-muted-foreground p-0 m-0">
-                               {formatCasualDate(task.start_date)}
-                            </p>
-                        </div>
+                                <span className="font-semibold">{task?.type}</span> for {" "}
+                                {task?.boq ? (
+                                    <Link to={`/boqs/boq?id=${task.boq}`} className="text-primary font-semibold hover:underline">
+                                        {task.boq}
+                                    </Link>
+                                ) : (
+                                    <span className="font-semibold">N/A</span>
+                                )}{" "}
+                                <p className="text-xs inline-block text-muted-foreground p-0 m-0">
+                                    {formatCasualDate(task.start_date)}
+                                </p>
+                            </div>
                         )}
-                        
                     </div>
                 </span>
                 <Button variant="outline" size="sm" onClick={() => openEditTaskDialog({ taskData: task, mode: 'updateStatus' })}>

--- a/crm/src/pages/Home/StatsGrid.tsx
+++ b/crm/src/pages/Home/StatsGrid.tsx
@@ -218,9 +218,9 @@ export const StatsGrid = () => {
         { title: "Total Task", data: statsData?.totalMeetings },
         { title: "Unique Meetings", data: statsData?.uniqueMeetings },
         { title: "Pending Task", data: statsData?.pendingTasks },
-        { title: "Pending BOQ", data: statsData?.pendingBoq },
-        { title: "BOQ Received", data: statsData?.boqReceived },
-        { title: "BOQ Sent", data: statsData?.boqSent },
+        { title: "Pending Projects", data: statsData?.pendingBoq },
+        { title: "Projects Received", data: statsData?.boqReceived },
+        { title: "Projects Sent", data: statsData?.boqSent },
         { title: "Hot Deals", data: statsData?.hotDeals },
     ];
 

--- a/crm/src/pages/Home/components/BoqBcsReviewTable.tsx
+++ b/crm/src/pages/Home/components/BoqBcsReviewTable.tsx
@@ -53,7 +53,7 @@ export const BoqBcsReviewTable = () => {
         return map;
     }, [teamUsers]);
 
-    const targetStatuses = new Set(["in progress", "in-progress", "partial boq submitted", "revision pending", "hold"]);
+    const targetStatuses = new Set(["new", "in progress", "in-progress", "partial boq submitted", "revision pending", "hold"]);
     const normalizeStatus = (status: string) => (status||"").toLowerCase().replace(/[_-]+/g, " ").replace(/\s+/g, " ").trim();
 
     const pendingWipEstimations = useMemo(() => {

--- a/crm/src/pages/Home/components/EstimationsReviewTable.tsx
+++ b/crm/src/pages/Home/components/EstimationsReviewTable.tsx
@@ -3,6 +3,7 @@ import { useFrappeGetDocList } from "frappe-react-sdk";
 import { ChevronDown, ChevronRight, Link2, SquarePen } from "lucide-react";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Button } from "@/components/ui/button";
+import { Link } from "react-router-dom";
 import { useDialogStore } from "@/store/dialogStore";
 import { cn } from "@/lib/utils";
 
@@ -84,6 +85,7 @@ const COMPLETED_STATUSES = new Set([
 ]);
 
 const WIP_STATUSES = new Set([
+  "new",
   "in progress",
   "in-progress",
   "partial boq submitted",
@@ -359,7 +361,14 @@ export const TaskTable = ({
               <tr key={item.name} className={cn("align-top", overdue ? "bg-red-50 hover:bg-red-100/50" : dueToday ? "bg-yellow-50 hover:bg-yellow-100/50" : "hover:bg-gray-50")}>
                 {showProjectName && (
                   <td className="px-3 py-2 text-sm text-gray-900">
-                    {projectMap.get(item.parent_project || "")?.boq_name || item.parent_project || "--"}
+                    {item.parent_project ? (
+                      <Link
+                        to={`/boqs/boq?id=${item.parent_project}`}
+                        className="text-primary font-semibold hover:underline"
+                      >
+                         {projectMap.get(item.parent_project)?.boq_name || item.parent_project}
+                      </Link>
+                    ) : "--"}
                   </td>
                 )}
                 <td className="px-3 py-2 text-sm text-gray-900">{item.package_name || item.title || "--"}</td>
@@ -695,15 +704,15 @@ export const EstimationsReviewTable = () => {
     const summaries: ProjectSummary[] = Array.from(grouped.entries()).map(([projectId, items]) => {
       const project = projectMap.get(projectId);
       const derivedValue = items.reduce((acc, item) => acc + (Number(item.value) || 0), 0);
+      // Use derived sum from estimation rows when they exist;
+      // fall back to legacy boq_value only when there are no estimation items.
+      const totalValue = items.length > 0 ? derivedValue : (Number(project?.boq_value) || 0);
 
       return {
         projectId,
         projectName: project?.boq_name || projectId,
         status: project?.boq_status || "--",
-        totalValue:
-          project?.boq_value !== undefined && project?.boq_value !== null
-            ? Number(project.boq_value)
-            : derivedValue,
+        totalValue,
         tasks: items.length,
         overdue: items.filter((item) => isOverdue(item.deadline, item.status)).length,
       };
@@ -900,7 +909,13 @@ export const EstimationsReviewTable = () => {
                                                     ) : (
                                                       <ChevronRight className="h-4 w-4 text-gray-500" />
                                                     )}
-                                                    {project.projectName}
+                                                    <Link
+                                                      to={`/boqs/boq?id=${project.projectId}`}
+                                                      className="text-primary font-semibold hover:underline"
+                                                      onClick={(e) => e.stopPropagation()}
+                                                    >
+                                                      {project.projectName}
+                                                    </Link>
                                                   </div>
                                                 </td>
                                                 <td className="px-3 py-2">

--- a/crm/src/pages/Home/components/SalesPerformanceTable.tsx
+++ b/crm/src/pages/Home/components/SalesPerformanceTable.tsx
@@ -235,7 +235,7 @@ export const SalesPerformanceTable: React.FC<SalesPerformanceTableProps> = ({ cl
             titlePrefix = "Unique Meetings";
             dialogItemType = 'Task';
         } else if (metricType === 'BOQ') {
-            titlePrefix = "BOQ Received";
+            titlePrefix = "Projects Received";
             formatterToUse = boqNameFormatter;
             dialogItemType = 'BOQ';
         }
@@ -455,7 +455,7 @@ export const SalesPerformanceTable: React.FC<SalesPerformanceTableProps> = ({ cl
                     {/* BOQ Row */}
                     <div className="mb-3">
                         <div className="text-[10px] font-medium uppercase tracking-wide text-muted-foreground mb-1.5 flex items-center gap-1">
-                            <FileText className="w-3 h-3" /> BOQ Received
+                            <FileText className="w-3 h-3" /> Projects Received
                         </div>
                         <div className="grid grid-cols-3 gap-2">
                             {periods.map(period => {

--- a/crm/src/pages/MyTeam/OverviewTab.tsx
+++ b/crm/src/pages/MyTeam/OverviewTab.tsx
@@ -146,9 +146,9 @@ export const OverviewTab = ({ member, tasks, contacts, boqs }: { member: Member;
 
         const allPossibleCards = {
             pendingTasks: { title: "Pending Tasks", data: statsData?.pendingTasks },
-            boqReceived: { title: "BOQs Received", data: statsData?.boqReceived },
-            boqSent: { title: "BOQs Sent", data: statsData?.boqSent },
-            pendingBoq: { title: "Pending BOQs", data: statsData?.pendingBoq },
+            boqReceived: { title: "Projects Received", data: statsData?.boqReceived },
+            boqSent: { title: "Projects Sent", data: statsData?.boqSent },
+            pendingBoq: { title: "Pending Projects", data: statsData?.pendingBoq },
             hotDeals: { title: "Hot Deals", data: statsData?.hotDeals },
             totalMeetings: { title: "Total Meetings", data: statsData?.totalMeetings },
             uniqueMeetings: { title: "Unique Meetings", data: statsData?.uniqueMeetings },

--- a/nirmaan_crm/nirmaan_crm/doctype/crm_boq/crm_boq.py
+++ b/nirmaan_crm/nirmaan_crm/doctype/crm_boq/crm_boq.py
@@ -36,6 +36,10 @@ class CRMBOQ(Document):
 
 	def on_update(self):
 		packages = self._get_selected_packages()
+		
+		# Cleanup tasks for removed packages first
+		self._cleanup_removed_package_tasks(packages)
+
 		if not packages:
 			return
 
@@ -53,6 +57,26 @@ class CRMBOQ(Document):
 			# BCS rows are created only when explicitly enabled from project create/edit flow.
 			if should_create_bcs:
 				self._create_project_estimation_if_missing(package_name, "BCS", assigned_to)
+
+	def on_trash(self):
+		"""Cleanup all associated tasks when the project is deleted."""
+		frappe.db.delete("CRM Project Estimation", {"parent_project": self.name})
+
+	def _cleanup_removed_package_tasks(self, current_packages):
+		"""Deletes all Project Estimation (BOQ/BCS) tasks for packages that are no longer selected."""
+		if self.is_new():
+			return
+
+		existing_tasks = frappe.get_all(
+			"CRM Project Estimation",
+			filters={"parent_project": self.name},
+			fields=["name", "package_name"]
+		)
+		
+		for task in existing_tasks:
+			# If the package_name of the task is not in the current selection, delete it
+			if task.package_name not in current_packages:
+				frappe.delete_doc("CRM Project Estimation", task.name, ignore_permissions=True)
 
 	def _get_selected_packages(self):
 		raw_packages = getattr(self, "boq_type", None)


### PR DESCRIPTION
…d BOQ-to-Project renaming

  - Make project names clickable links across estimations, pending tasks, and BOQ/BCS review tables for direct navigation to project detail page
  - Add confirmation dialog when removing packages that have associated estimation rows, with backend cleanup of orphaned estimation tasks
  - Handle legacy package visibility in edit form to prevent accidental deletion of migrated data
  - Fix total BOQ value falling back to stale legacy value when estimation rows sum to zero
  - Include "New" status in WIP and Pending filters for estimations review
  - Add "Future Prospect" priority option with green badge styling
  - Enforce at least one package required validation on project edit
  - Rename remaining BOQ labels to Project across company details, stats, sales performance, and team overview pages