### PR TITLE
feat: derive BOQ value from package rows + package-wise financial bre…

### DIFF
--- a/crm/src/pages/BOQS/BOQ.tsx
+++ b/crm/src/pages/BOQS/BOQ.tsx
@@ -8,7 +8,7 @@ import { CRMContacts } from "@/types/NirmaanCRM/CRMContacts";
 import { CRMNote } from "@/types/NirmaanCRM/CRMNote";
 import { CRMTask } from "@/types/NirmaanCRM/CRMTask";
 import { useFrappeGetDoc, useFrappeGetDocList, useSWRConfig, useFrappeUpdateDoc } from "frappe-react-sdk";
-import { AlertTriangle, ArrowLeft, ChevronDown, ChevronLeft, ChevronRight, Plus, RefreshCw, SquarePen, Wallet, Calendar, Clock, FolderOpen, AlarmClock, CalendarPlus, History } from "lucide-react";
+import { AlertTriangle, ArrowLeft, ChevronDown, ChevronLeft, ChevronRight, Plus, RefreshCw, SquarePen, Wallet, Calendar, Clock, FolderOpen, AlarmClock, CalendarPlus, History, ExternalLink } from "lucide-react";
 import React, { useMemo, useState } from "react";
 import { useStateSyncedWithParams } from "@/hooks/useSearchParamsManager";
 import { useStatusStyles, isCascadeDerivedBoqStatus } from "@/hooks/useStatusStyles";
@@ -29,6 +29,7 @@ import { useTaskCreationHandler } from "@/hooks/useTaskCreationHandler";
 import { FullPageSkeleton } from "@/components/common/FullPageSkeleton";
 import { parsePackages } from "@/constants/boqPackages";
 import { ProjectEstimationsTable, CRMProjectEstimation } from "./components/ProjectEstimationsTable";
+import { FinancialBreakdownDialog } from "./components/FinancialBreakdownDialog";
 import { BoqBcsTaskExport } from "./components/BoqBcsTaskExport";
 import { cn } from "@/lib/utils";
 
@@ -185,16 +186,19 @@ const ProjectOverviewCard = ({ boq, contact, company, estimations }: { boq: CRMB
     const isSalesProfile = role === 'Nirmaan Sales User Profile';
     const canManageStatus = role === 'Nirmaan Sales User Profile' || role === 'Nirmaan Admin User Profile' || role === 'Nirmaan Estimations Lead Profile';
 
+    const [financialOpen, setFinancialOpen] = useState(false);
+
     // Total should be BOQ-only, not BOQ+BCS.
     const boqRows = (estimations || []).filter((est) => (est.document_type || '').toUpperCase() === 'BOQ');
     const bcsRows = (estimations || []).filter((est) => (est.document_type || '').toUpperCase() === 'BCS');
     const boqTotalFromRows = boqRows.reduce((sum, est) => sum + (Number(est.value) || 0), 0);
     const bcsTotalFromRows = bcsRows.reduce((sum, est) => sum + (Number(est.value) || 0), 0);
 
-    // If estimation rows exist, always use the aggregated sum (even if zero);
-    // fall back to legacy boq_value only when there are no BOQ estimation rows at all.
+    // Always show the project's stored value (boq_value) — it is kept in sync with
+    // the package rows by the backend rollup. Fall back to the live package sum only
+    // when the stored field is empty (e.g. a project not yet rolled up).
     const hasBoqEstimations = boqRows.length > 0;
-    const totalValue = hasBoqEstimations ? boqTotalFromRows : (Number(boq?.boq_value) || 0);
+    const totalValue = Number(boq?.boq_value) || boqTotalFromRows;
 
     // Incomplete-data warnings: a row counts as "pending" when its value is null/undefined or 0.
     const isValueMissing = (v: number | null | undefined) => v == null || Number(v) === 0;
@@ -212,6 +216,8 @@ const ProjectOverviewCard = ({ boq, contact, company, estimations }: { boq: CRMB
     const showMarginWarning = showMargin && (
         boqRows.length === 0 || bcsRows.length === 0 || boqMissingCount > 0 || bcsMissingCount > 0
     );
+    // Drives the amber state of the financial-breakdown card / info icon.
+    const financialIncomplete = isBcsIncomplete || showMarginWarning || totalValue === 0;
 
     const boqWarningMsg = `${boqMissingCount} of ${boqRows.length} BOQ package(s) have no value recorded. Total may be understated. Click to view.`;
     const marginWarningMsg = (() => {
@@ -295,40 +301,64 @@ const ProjectOverviewCard = ({ boq, contact, company, estimations }: { boq: CRMB
                     </div>
 
                     {!isSalesProfile && showMargin && (
-                        <div className={cn("flex items-center gap-2 p-3 rounded-lg border",
-                            isBcsIncomplete ? "bg-amber-50/60 border-amber-200" :
-                            !canComputeMargin ? "bg-gray-50/50 border-gray-200" :
-                            isProfit ? "bg-emerald-50/50 border-emerald-100/60" : "bg-red-50/50 border-red-100/60"
-                        )}>
-                            <div className={cn("p-1.5 rounded-md",
-                                isBcsIncomplete ? "bg-amber-100 text-amber-700" :
-                                !canComputeMargin ? "bg-gray-100 text-gray-500" :
-                                isProfit ? "bg-emerald-100 text-emerald-700" : "bg-red-100 text-red-600"
-                            )}>
-                                <Wallet className="w-4 h-4" />
-                            </div>
-                            <div>
-                                <p className="text-[10px] uppercase font-bold text-gray-500 tracking-wider">Margin</p>
-                                {isBcsIncomplete ? (
-                                    <p className="text-sm font-bold text-amber-700 inline-flex items-center gap-1.5">
-                                        BCS Incomplete
-                                        <WarningIcon message={marginWarningMsg} />
-                                    </p>
-                                ) : canComputeMargin ? (
-                                    <p className={cn("text-sm font-bold inline-flex items-center gap-1.5", isProfit ? "text-emerald-700" : "text-red-600")}>
-                                        {isProfit ? "Profit" : "Loss"}: {marginPercent.toFixed(1)}%
-                                        {showMarginWarning && <WarningIcon message={marginWarningMsg} />}
-                                    </p>
-                                ) : (
-                                    <p className="text-sm font-bold text-gray-500 inline-flex items-center gap-1.5">
-                                        --
-                                        {showMarginWarning && <WarningIcon message={marginWarningMsg} />}
-                                    </p>
-                                )}
-                            </div>
-                        </div>
+                        <Tooltip>
+                            <TooltipTrigger asChild>
+                                <button
+                                    type="button"
+                                    onClick={() => setFinancialOpen(true)}
+                                    aria-label="View financial breakdown"
+                                    aria-haspopup="dialog"
+                                    aria-expanded={financialOpen}
+                                    className={cn("group text-left flex items-center gap-2 p-3 rounded-lg border transition-colors cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/40",
+                                        isBcsIncomplete ? "bg-amber-50/60 border-amber-200 hover:bg-amber-50" :
+                                        !canComputeMargin ? "bg-gray-50/50 border-gray-200 hover:bg-gray-100/70" :
+                                        isProfit ? "bg-emerald-50/50 border-emerald-100/60 hover:bg-emerald-50" : "bg-red-50/50 border-red-100/60 hover:bg-red-50"
+                                    )}
+                                >
+                                    <div className={cn("p-1.5 rounded-md shrink-0",
+                                        isBcsIncomplete ? "bg-amber-100 text-amber-700" :
+                                        !canComputeMargin ? "bg-gray-100 text-gray-500" :
+                                        isProfit ? "bg-emerald-100 text-emerald-700" : "bg-red-100 text-red-600"
+                                    )}>
+                                        <Wallet className="w-4 h-4" />
+                                    </div>
+                                    <div className="min-w-0 flex-1">
+                                        <p className="text-[10px] uppercase font-bold text-gray-500 tracking-wider">Margin</p>
+                                        {isBcsIncomplete ? (
+                                            <p className="text-sm font-bold text-amber-700 leading-tight">BCS Incomplete</p>
+                                        ) : canComputeMargin ? (
+                                            <p className={cn("text-sm font-bold leading-tight inline-flex items-center gap-1", isProfit ? "text-emerald-700" : "text-red-600")}>
+                                                {isProfit ? "Profit" : "Loss"}: {Math.abs(marginPercent).toFixed(1)}%
+                                                {/* Non-color cue that the % is based on incomplete data; the card's
+                                                    own tooltip already explains it (marginWarningMsg) on hover. */}
+                                                {showMarginWarning && <AlertTriangle className="w-3 h-3 text-amber-500" aria-label="based on incomplete data" />}
+                                            </p>
+                                        ) : (
+                                            <p className="text-sm font-bold text-gray-500 leading-tight">--</p>
+                                        )}
+                                    </div>
+                                    <ExternalLink className="w-3.5 h-3.5 shrink-0 self-start text-blue-600 group-hover:text-blue-700 transition-colors" />
+                                </button>
+                            </TooltipTrigger>
+                            <TooltipContent className="max-w-xs">
+                                {financialIncomplete ? marginWarningMsg : "View the package-wise BOQ vs BCS breakdown and margin."}
+                            </TooltipContent>
+                        </Tooltip>
                     )}
                 </div>
+
+                {!isSalesProfile && showMargin && (
+                    <FinancialBreakdownDialog
+                        open={financialOpen}
+                        onOpenChange={setFinancialOpen}
+                        projectName={boq?.boq_name || boq?.name || "Project"}
+                        companyName={company?.company_name}
+                        boqRows={boqRows}
+                        bcsRows={bcsRows}
+                        totalValue={totalValue}
+                        bcsIncomplete={isBcsIncomplete}
+                    />
+                )}
             </div>
 
             {/* Right Column: Details Grid */}

--- a/crm/src/pages/BOQS/EditBoqForm.tsx
+++ b/crm/src/pages/BOQS/EditBoqForm.tsx
@@ -266,6 +266,12 @@ export const EditBoqForm = ({ onSuccess }: EditBoqFormProps) => {
       if (typeof cascadeDeadline === "number") {
         dataToSave.cascade_deadline = cascadeDeadline;
       }
+      // When the project has BOQ estimation rows, boq_value is derived (sum of
+      // package values) and shown read-only. Don't send the stale/derived value —
+      // the backend recomputes it from the child rows on save.
+      if (hasBoqEstimations) {
+        delete dataToSave.boq_value;
+      }
       await updateDoc("CRM BOQ", boqData.name, {
         ...dataToSave, boq_link: dataToSave.boq_link || boqData.boq_link, remarks: dataToSave?.remarks || boqData.remarks, boq_sub_status: null
       });

--- a/crm/src/pages/BOQS/components/FinancialBreakdownDialog.tsx
+++ b/crm/src/pages/BOQS/components/FinancialBreakdownDialog.tsx
@@ -1,0 +1,253 @@
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from "@/components/ui/dialog";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { cn } from "@/lib/utils";
+import { TrendingUp, TrendingDown, AlertTriangle, ChevronDown, Minus } from "lucide-react";
+import { CRMProjectEstimation } from "./ProjectEstimationsTable";
+
+interface FinancialBreakdownDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  projectName: string;
+  companyName?: string;
+  boqRows: CRMProjectEstimation[];
+  bcsRows: CRMProjectEstimation[];
+  /**
+   * Resolved BOQ total from the detail-page tile (`Number(boq_value) || row sum`).
+   * Passed in so the dialog's headline margin/total ALWAYS matches the tile that
+   * opened it — never recomputed from a different denominator here.
+   */
+  totalValue: number;
+  /** The tile's BCS-incomplete state, so the dialog mirrors the tile exactly. */
+  bcsIncomplete?: boolean;
+}
+
+type Row = { name: string; boq: number | null; bcs: number | null };
+
+const EPS = 0.005; // treat |amount| < 0.005L as break-even / zero
+const inr = (v: number) =>
+  (Number(v) || 0).toLocaleString("en-IN", { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+const fmt = (v: number | null) => (v == null ? "—" : `₹${inr(v)}L`);
+const fmtSigned = (v: number) => `${v < 0 ? "−" : "+"}₹${inr(Math.abs(v))}L`;
+const norm = (s?: string) => (s || "").trim();
+// Demote extreme percentages (tiny BOQ vs large BCS) — the rupee delta is the real figure.
+const pctLabel = (pct: number) => (Math.abs(pct) >= 300 ? ">300%" : `${Math.abs(pct).toFixed(1)}%`);
+
+// A non-positive BOQ or a 0/null BCS is treated as "not entered" — no real margin.
+const pkgMargin = (boq: number | null, bcs: number | null) => {
+  if (boq == null || boq <= 0 || bcs == null || bcs === 0) return null;
+  return (1 - bcs / boq) * 100;
+};
+// BOQ recorded, BCS not yet entered.
+const bcsPending = (r: Row) => r.boq != null && r.boq > 0 && (r.bcs == null || r.bcs === 0);
+// Cost recorded but no BOQ value — a real loss that must reconcile with the net.
+const costNoValue = (r: Row) => r.bcs != null && r.bcs !== 0 && (r.boq == null || r.boq <= 0);
+const costCell = (r: Row) => (r.bcs != null && r.bcs !== 0 ? fmt(r.bcs) : "—");
+
+export const FinancialBreakdownDialog = ({
+  open,
+  onOpenChange,
+  projectName,
+  companyName,
+  boqRows,
+  bcsRows,
+  totalValue,
+  bcsIncomplete,
+}: FinancialBreakdownDialogProps) => {
+  // Pair each package's BOQ value with its BCS value (matched by package name).
+  const packages = new Map<string, { boq: number | null; bcs: number | null }>();
+  boqRows.forEach((r) => {
+    const k = norm(r.package_name) || "(unnamed)";
+    const cur = packages.get(k) || { boq: null, bcs: null };
+    cur.boq = (cur.boq || 0) + (Number(r.value) || 0);
+    packages.set(k, cur);
+  });
+  bcsRows.forEach((r) => {
+    const k = norm(r.package_name) || "(unnamed)";
+    const cur = packages.get(k) || { boq: null, bcs: null };
+    cur.bcs = (cur.bcs || 0) + (Number(r.value) || 0);
+    packages.set(k, cur);
+  });
+
+  const rows: Row[] = Array.from(packages.entries()).map(([name, v]) => ({ name, ...v }));
+  const bcsTotal = bcsRows.reduce((s, r) => s + (Number(r.value) || 0), 0);
+  const canMargin = totalValue > 0;
+  const marginPercent = canMargin ? (1 - bcsTotal / totalValue) * 100 : 0;
+  const netAmount = totalValue - bcsTotal;
+  const breakEven = canMargin && Math.abs(netAmount) < EPS;
+  const netProfit = netAmount > EPS;
+  const missingBcs = rows.filter((r) => bcsPending(r) || costNoValue(r)).length;
+  const showIncomplete = !!bcsIncomplete || missingBcs > 0;
+
+  // Net-margin visual state (drives the KPI tile colour + icon).
+  const net = !canMargin
+    ? { bg: "bg-muted/30", text: "text-foreground", Icon: Minus }
+    : showIncomplete
+    ? { bg: "bg-amber-50/60 border-amber-200", text: "text-amber-700", Icon: AlertTriangle }
+    : breakEven
+    ? { bg: "bg-muted/30", text: "text-foreground", Icon: Minus }
+    : netProfit
+    ? { bg: "bg-emerald-50/60 border-emerald-200", text: "text-emerald-700", Icon: TrendingUp }
+    : { bg: "bg-red-50/60 border-red-200", text: "text-red-600", Icon: TrendingDown };
+
+  // Per-package profit/loss cell — rupee delta primary, capped % secondary.
+  const renderRowMargin = (r: Row) => {
+    const pct = pkgMargin(r.boq, r.bcs);
+    if (pct != null) {
+      const amount = (r.boq as number) - (r.bcs as number);
+      const even = Math.abs(amount) < EPS;
+      const Icon = even ? Minus : amount > 0 ? TrendingUp : TrendingDown;
+      const tone = even ? "text-muted-foreground" : amount > 0 ? "text-emerald-700" : "text-red-600";
+      return (
+        <span className={cn("inline-flex items-baseline gap-1.5", tone)}>
+          <Icon className="w-3.5 h-3.5 self-center" aria-label={even ? "break-even" : amount > 0 ? "profit" : "loss"} />
+          <span className="font-semibold tabular-nums">{fmtSigned(amount)}</span>
+          <span className="text-[11px] font-medium opacity-70 tabular-nums">{pctLabel(pct)}</span>
+        </span>
+      );
+    }
+    if (costNoValue(r)) {
+      // Cost with no BOQ value — a full loss; shown so the ledger reconciles with the net.
+      return (
+        <span className="inline-flex items-baseline gap-1.5 text-red-600">
+          <TrendingDown className="w-3.5 h-3.5 self-center" aria-label="loss" />
+          <span className="font-semibold tabular-nums">{fmtSigned(-(r.bcs as number))}</span>
+          <span className="text-[11px] font-medium opacity-70">no BOQ</span>
+        </span>
+      );
+    }
+    if (bcsPending(r)) return <span className="text-xs font-medium text-amber-600">BCS pending</span>;
+    return <span className="text-xs font-medium text-muted-foreground">—</span>;
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>Margin Breakdown</DialogTitle>
+          <DialogDescription>
+            {projectName}
+            {companyName ? ` · ${companyName}` : ""}
+          </DialogDescription>
+        </DialogHeader>
+
+        {/* KPI summary — three cards in one row */}
+        <div className="grid grid-cols-3 gap-2.5">
+          <div className="rounded-lg border bg-muted/30 p-3 min-w-0">
+            <p className="text-[10px] sm:text-[11px] uppercase font-bold text-muted-foreground tracking-wide">Total BOQ</p>
+            <p className="text-base sm:text-lg font-bold tabular-nums whitespace-nowrap mt-1">{fmt(totalValue)}</p>
+          </div>
+          <div className="rounded-lg border bg-muted/30 p-3 min-w-0">
+            <p className="text-[10px] sm:text-[11px] uppercase font-bold text-muted-foreground tracking-wide">Total BCS</p>
+            <p className="text-base sm:text-lg font-bold tabular-nums whitespace-nowrap mt-1">{fmt(bcsTotal)}</p>
+          </div>
+          <div className={cn("rounded-lg border p-3 min-w-0", net.bg)}>
+            <p className="text-[10px] sm:text-[11px] uppercase font-bold text-muted-foreground tracking-wide">Net Margin</p>
+            {!canMargin ? (
+              <p className="text-base sm:text-lg font-bold mt-1">—</p>
+            ) : showIncomplete ? (
+              // BCS pending — do NOT show a percentage (it would be misleading); flag it instead.
+              <p className="text-sm sm:text-base font-bold text-amber-700 inline-flex items-center gap-1.5 whitespace-nowrap mt-1">
+                <AlertTriangle className="w-4 h-4 shrink-0" />
+                Missing BCS
+              </p>
+            ) : (
+              <>
+                <p className={cn("text-base sm:text-lg font-bold tabular-nums inline-flex items-center gap-1 whitespace-nowrap mt-1", net.text)}>
+                  <net.Icon className="w-4 h-4 shrink-0" aria-hidden />
+                  {pctLabel(marginPercent)}
+                </p>
+                <p className={cn("text-xs sm:text-sm font-semibold tabular-nums whitespace-nowrap opacity-80", net.text)}>
+                  ({fmtSigned(netAmount)})
+                </p>
+              </>
+            )}
+          </div>
+        </div>
+
+        {showIncomplete && (
+          <p className="inline-flex items-center gap-1 text-[11px] text-amber-700">
+            <AlertTriangle className="w-3 h-3 shrink-0" />
+            Margin not final — {missingBcs} package{missingBcs > 1 ? "s" : ""} missing BCS.
+          </p>
+        )}
+
+        {/* How the margin is calculated — sits directly under Net Margin */}
+        <details className="group rounded-lg bg-muted/40 px-4 py-3">
+          <summary className="flex items-center justify-between cursor-pointer list-none text-[10px] uppercase font-bold text-muted-foreground tracking-wider rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/40">
+            How is margin calculated?
+            <ChevronDown className="w-4 h-4 transition-transform group-open:rotate-180" />
+          </summary>
+          <div className="mt-2 space-y-1">
+            <p className="font-mono text-xs text-muted-foreground">Total BOQ = {fmt(totalValue)}</p>
+            <p className="font-mono text-xs text-muted-foreground">Total BCS = {fmt(bcsTotal)}</p>
+            <p className="font-mono text-xs text-muted-foreground">
+              Margin % = ( 1 − Total BCS ÷ Total BOQ ) × 100 = {canMargin ? pctLabel(marginPercent) : "—"}
+            </p>
+            <p className="font-mono text-xs text-muted-foreground">
+              Net = Total BOQ − Total BCS = {canMargin ? fmtSigned(netAmount) : "—"}
+            </p>
+          </div>
+        </details>
+
+        {/* Package ledger — desktop table */}
+        <p className="text-[10px] uppercase font-bold text-muted-foreground tracking-wider mt-1">Packages</p>
+        <div className="hidden sm:block">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Package</TableHead>
+                <TableHead className="text-right">BOQ</TableHead>
+                <TableHead className="text-right">BCS</TableHead>
+                <TableHead className="text-right">Profit / Loss</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {rows.length === 0 ? (
+                <TableRow>
+                  <TableCell colSpan={4} className="text-center h-20 text-muted-foreground">
+                    No packages added yet.
+                  </TableCell>
+                </TableRow>
+              ) : (
+                rows.map((r) => (
+                  <TableRow key={r.name}>
+                    <TableCell className="font-medium">{r.name}</TableCell>
+                    <TableCell className="text-right tabular-nums">{fmt(r.boq)}</TableCell>
+                    <TableCell className={cn("text-right tabular-nums", bcsPending(r) && "text-amber-600")}>
+                      {costCell(r)}
+                    </TableCell>
+                    <TableCell className="text-right">
+                      <span className="inline-flex justify-end">{renderRowMargin(r)}</span>
+                    </TableCell>
+                  </TableRow>
+                ))
+              )}
+            </TableBody>
+          </Table>
+        </div>
+
+        {/* Package ledger — mobile stacked cards (no horizontal scroll) */}
+        <div className="sm:hidden space-y-2">
+          {rows.length === 0 ? (
+            <p className="text-center text-sm text-muted-foreground py-8">No packages added yet.</p>
+          ) : (
+            rows.map((r) => (
+              <div key={r.name} className="rounded-lg border bg-card p-3">
+                <div className="flex items-center justify-between gap-2">
+                  <span className="min-w-0 truncate font-semibold text-sm" title={r.name}>
+                    {r.name}
+                  </span>
+                  <span className="shrink-0 text-sm">{renderRowMargin(r)}</span>
+                </div>
+                <div className="mt-1 text-xs text-muted-foreground tabular-nums">
+                  BOQ {fmt(r.boq)} · BCS{" "}
+                  <span className={cn(bcsPending(r) && "text-amber-600")}>{costCell(r)}</span>
+                </div>
+              </div>
+            ))
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/nirmaan_crm/integrations/controllers/crm_project_estimation.py
+++ b/nirmaan_crm/integrations/controllers/crm_project_estimation.py
@@ -1,12 +1,16 @@
 import frappe
-from nirmaan_crm.nirmaan_crm.doctype.crm_boq.crm_boq import recompute_parent_project_status
+from nirmaan_crm.nirmaan_crm.doctype.crm_boq.crm_boq import (
+    recompute_parent_project_status,
+    recompute_parent_project_value,
+)
 
 
 def on_estimation_update(doc, method):
     """Triggered after CRM Project Estimation save.
 
-    Cascades the change up to parent CRM BOQ.boq_status via recompute.
-    Only BOQ-type estimations participate in the cascade; BCS rows are ignored.
+    Cascades the change up to parent CRM BOQ — both boq_status (derived state) and
+    boq_value (sum of package values). Only BOQ-type estimations participate; BCS
+    rows do not affect either.
     """
     if doc.document_type != "BOQ":
         return
@@ -16,3 +20,7 @@ def on_estimation_update(doc, method):
         recompute_parent_project_status(doc.parent_project)
     except Exception:
         frappe.log_error(frappe.get_traceback(), "BOQ status cascade failed")
+    try:
+        recompute_parent_project_value(doc.parent_project)
+    except Exception:
+        frappe.log_error(frappe.get_traceback(), "BOQ value rollup failed")

--- a/nirmaan_crm/nirmaan_crm/doctype/crm_boq/crm_boq.py
+++ b/nirmaan_crm/nirmaan_crm/doctype/crm_boq/crm_boq.py
@@ -82,6 +82,12 @@ class CRMBOQ(Document):
 		# Handles lock-exit (manual status change to non-lock) and post-deletion re-derivation.
 		recompute_parent_project_status(self.name)
 
+		# Cascade: re-derive boq_value as the sum of child BOQ estimation values.
+		# Runs here too so package add/remove (which create/delete estimation rows
+		# inside this on_update) are reflected — estimation deletion does not fire the
+		# CRM Project Estimation on_update hook.
+		recompute_parent_project_value(self.name)
+
 	def _cascade_deadline_to_children(self):
 		"""Overwrite `deadline` on every child CRM Project Estimation when BOQ submission date changes.
 
@@ -243,6 +249,52 @@ def recompute_parent_project_status(project_name):
 			update_modified=True,
 		)
 		_log_auto_status_version(project_name, current_status, derived)
+
+
+def recompute_parent_project_value(project_name, update_modified=True):
+	"""Re-derive CRM BOQ.boq_value as the sum of child BOQ-type estimation values.
+
+	Keeps the persisted parent value (read by company lists & reports) in sync with
+	the package rows shown on the detail page. Unlike status, value is recomputed
+	regardless of LOCK_STATUSES — a Won/Lost project should still reflect its total.
+
+	Guard: if the project has no BOQ estimation rows it is a legacy/single-value
+	project, so its manually-entered boq_value is left untouched (mirrors the
+	frontend `hasBoqEstimations` fallback). Never wipes a legacy value to 0.
+
+	update_modified: live callers (package edit / project save) use True (default)
+	so the project's "Updated" date reflects the real change — matching the status
+	recompute. The one-time backfill patch passes False so it does not rewrite
+	historical timestamps in bulk.
+	"""
+	if not project_name or not frappe.db.exists("CRM BOQ", project_name):
+		return
+
+	values = frappe.get_all(
+		"CRM Project Estimation",
+		filters={"parent_project": project_name, "document_type": "BOQ"},
+		pluck="value",
+	)
+	if not values:
+		return
+
+	total = 0.0
+	for raw in values:
+		try:
+			total += float(raw or 0)
+		except (TypeError, ValueError):
+			continue
+
+	total = round(total, 2)
+	# boq_value is a Data field; store a clean string ("696" not "696.0").
+	new_value = str(int(total)) if float(total).is_integer() else str(total)
+
+	current = frappe.db.get_value("CRM BOQ", project_name, "boq_value")
+	if (current or "") != new_value:
+		frappe.db.set_value(
+			"CRM BOQ", project_name, "boq_value", new_value,
+			update_modified=update_modified,
+		)
 
 
 def _log_auto_status_version(project_name, old_status, new_status):

--- a/nirmaan_crm/patches.txt
+++ b/nirmaan_crm/patches.txt
@@ -14,3 +14,4 @@ nirmaan_crm.patches.v0_0.migrate_legacy_boq_projects_to_estimations
 nirmaan_crm.patches.v0_0.rename_legacy_boq_status_values
 nirmaan_crm.patches.v0_0.recompute_boq_status_from_estimations
 nirmaan_crm.patches.v0_0.revert_cascaded_done_estimations
+nirmaan_crm.patches.v0_0.recompute_boq_value_from_estimations

--- a/nirmaan_crm/patches/v0_0/recompute_boq_value_from_estimations.py
+++ b/nirmaan_crm/patches/v0_0/recompute_boq_value_from_estimations.py
@@ -1,0 +1,32 @@
+import frappe
+from nirmaan_crm.nirmaan_crm.doctype.crm_boq.crm_boq import recompute_parent_project_value
+
+
+def execute():
+    """Backfill CRM BOQ.boq_value from child BOQ estimation values.
+
+    Existing projects never had their parent boq_value rolled up from the package
+    rows, so multi-package / new-flow projects sit at a stale value (often "0").
+    This recomputes boq_value = sum(child BOQ estimation values) for every project.
+
+    Uses recompute_parent_project_value, which:
+      - writes with update_modified=False (the "Updated" timestamp is preserved), and
+      - skips legacy projects that have no BOQ estimation rows (their manually
+        entered value is left untouched, never wiped to 0).
+    """
+
+    candidates = frappe.get_all("CRM BOQ", order_by="creation asc", pluck="name")
+
+    print(f"[boq_value backfill] processing {len(candidates)} projects")
+
+    processed = 0
+    for project_name in candidates:
+        # Backfill must NOT rewrite historical "Updated" timestamps in bulk.
+        recompute_parent_project_value(project_name, update_modified=False)
+        processed += 1
+        if processed % 100 == 0:
+            frappe.db.commit()
+            print(f"[boq_value backfill] committed batch — {processed}/{len(candidates)}")
+
+    frappe.db.commit()
+    print(f"[boq_value backfill] done — {processed} projects evaluated")


### PR DESCRIPTION
…akdown dialog

Backend — make CRM BOQ.boq_value an authoritative rollup of its child BOQ-type estimation values instead of a manually-entered field:
- Add recompute_parent_project_value() in crm_boq.py, cascaded on estimation save and on BOQ on_update (covers package add/remove, where estimation deletion doesn't fire the child hook).
- Recompute regardless of LOCK_STATUSES, but never wipe a legacy single-value project (no BOQ rows) to 0.
- Store a clean string ("696" not "696.0"); update_modified=False for backfill so historical timestamps are preserved.
- Add patches/v0_0/recompute_boq_value_from_estimations.py to backfill existing projects, registered in patches.txt.

Frontend:
- BOQ.tsx: total now reads stored boq_value (kept in sync by the rollup), falling back to the live package sum only when empty.
- Turn the Margin tile into a clickable button opening a new FinancialBreakdownDialog with the package-wise BOQ vs BCS breakdown, margin, and incomplete-data cues.
- EditBoqForm.tsx: drop the derived boq_value from the save payload when estimation rows exist, so the backend rollup stays source of truth.