### PR TITLE
feat: Unknown-contact placeholder + inline resolve for tasks

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -57,7 +57,7 @@ nirmaan_crm/
 | DocType | Purpose |
 |---------|---------|
 | CRM Company | Lead/company records with assigned sales, priority |
-| CRM Contacts | Contact persons linked to companies |
+| CRM Contacts | Contact persons linked to companies (incl. global `unknown@nirmaan.app` placeholder — see Unknown Contact Placeholder) |
 | CRM BOQ | Project container with package-based estimation pipeline (UI: 'Projects') |
 | CRM Project Estimation | Per-package estimation child of CRM BOQ (BOQ/BCS per package) |
 | CRM BOQ Package | Master package list with lead auto-routing (managed via `/team/packages` UI; seed fixture removed Apr 2026) |
@@ -113,6 +113,12 @@ Custom permission query conditions in `permissions.py`:
 User creation auto-generates CRM Users profile via `integrations/controllers/crm_users.py`.
 
 4 role profiles exist: Admin, Sales, Estimations User, Estimations Lead. The Lead profile shares backend roles with Estimations User but is differentiated by role-profile name string.
+
+## Unknown Contact Placeholder
+
+A CRM Task effectively needs a contact, but a company can exist with zero contacts. To let a task still be logged, a single **global placeholder contact** `unknown@nirmaan.app` (first name "Unknown", no company) is seeded via `patches/v0_0/seed_unknown_contact.py`. The shared id lives in `integrations/controllers/unknown_contact.py` (`UNKNOWN_CONTACT`), mirrored on the frontend by `crm/src/constants/unknownContact.ts` (`UNKNOWN_CONTACT_ID`).
+
+Resolution is **manual/inline — there is no doc_events hook**: from the task update dialog the user either selects an existing company contact or creates a new one, which replaces the placeholder on that task (frontend `ResolveContactSection`). `CRM Contacts.before_insert` (`crm_contacts.py`) still stamps `assigned_sales = owner` for Sales-user creators; Admins pick `assigned_sales` in the resolve form.
 
 ## Database Migrations
 

--- a/crm/CLAUDE.md
+++ b/crm/CLAUDE.md
@@ -152,7 +152,7 @@ Each page typically contains:
 
 - **BOQ.tsx** - Multi-mode editing (details, status, attachment); Margin tile (Profit/Loss/BCS Incomplete states) + pending-data warnings on Project Overview
 - **TaskList.tsx** - Infinite scroll, status filtering, date grouping
-- **EditTaskForm.tsx** - Task profile-aware (Sales vs Estimates have different fields)
+- **EditTaskForm.tsx** - Task profile-aware (Sales vs Estimates have different fields); shows an inline **Resolve Contact** collapse (`ResolveContactSection`) when the task's contact is the Unknown placeholder
 - **Reports** - Hub at `/reports` with sub-reports: `SalesCohortReport` (cohort progression matrix; single-month timeline vs multi-month range view, contiguous-month selection rule) and `FlowReport` (3-month outcome funnel). Status canon in `pages/Reports/utils/cohortStatusGroups.ts`; month-range utilities in `cohortRange.ts`; flow buckets declarative in `flowBuckets.ts`.
 
 ### New Pages (April 2026)
@@ -170,6 +170,14 @@ Tasks have a `task_profile` field: `'Sales' | 'Estimates'`
 
 - Different form fields per profile
 - Admin users see `selectTaskProfileDialog` to choose profile on creation
+
+## Unknown Contact Resolve Flow
+
+Sales task forms (`NewTaskForm`, `EditTaskForm` scheduleNext) offer a global **"Unknown"** placeholder contact (`src/constants/unknownContact.ts` → `UNKNOWN_CONTACT_ID`, backend id `unknown@nirmaan.app`) so a task can be logged for a company that has no real contact yet.
+
+- In the task update dialog, when the task's contact is the placeholder, `Tasks/ResolveContactSection.tsx` renders an **inline collapsible** panel that first lets the user **select an existing company contact** (Unknown excluded) or switch to **create a new one** (company auto-set from the task, `assigned_sales` picker Admin-only). Either path links the contact to the task **directly (no second dialog)**; a local `resolvedContact` state hides the panel and updates the header immediately.
+- `EditTaskForm` contact lists filter by **`taskData.company`** (not the linked contact's company, which is empty for the placeholder), so a company's real contacts — including a just-resolved one — load correctly. Rescheduling carries the resolved contact into the `scheduleNext` reopen.
+- Backend/data handling: [../.claude/CLAUDE.md](../.claude/CLAUDE.md) → "Unknown Contact Placeholder".
 
 ## Mobile Layout
 

--- a/crm/src/constants/unknownContact.ts
+++ b/crm/src/constants/unknownContact.ts
@@ -1,0 +1,13 @@
+// The single, global placeholder contact used when a company has no real
+// contact yet. A task can be attached to it so it can still be logged; a
+// backend hook (reassign_unknown_tasks) moves the task onto the real contact
+// once one is created for the company.
+//
+// Must match UNKNOWN_CONTACT in
+// nirmaan_crm/integrations/controllers/unknown_contact.py
+export const UNKNOWN_CONTACT_ID = "unknown@nirmaan.app";
+
+export const UNKNOWN_CONTACT_OPTION = {
+  label: "Unknown",
+  value: UNKNOWN_CONTACT_ID,
+};

--- a/crm/src/pages/Contacts/NewContactForm.tsx
+++ b/crm/src/pages/Contacts/NewContactForm.tsx
@@ -207,6 +207,7 @@ const dataToSave={
     full_name:`${values.first_name} ${values.last_name}`
 
 }
+
       if (isEditMode) {
         // UPDATE logic
         let fileUrl = initialData.visiting_card || null; // Start with the existing URL

--- a/crm/src/pages/Tasks/EditTaskForm.tsx
+++ b/crm/src/pages/Tasks/EditTaskForm.tsx
@@ -12,12 +12,14 @@ import { useFrappeCreateDoc, useFrappeGetDoc, useFrappeUpdateDoc, useSWRConfig,u
 import { useForm } from "react-hook-form";
 import * as z from "zod";
 import ReactSelect from "react-select";
-import { useEffect,useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { formatDate, formatTime12Hour,formatDateWithOrdinal } from "@/utils/FormatDate";
-import { Calendar, Clock } from "lucide-react"; // Import icons for a nicer UI
+import { Building2, Calendar, Clock } from "lucide-react"; // Import icons for a nicer UI
 import { salesTaskTypeOptions } from "@/constants/dropdownData";
 import { useUserRoleLists } from "@/hooks/useUserRoleLists"
 import { CRMContacts } from "@/types/NirmaanCRM/CRMContacts";
+import { UNKNOWN_CONTACT_ID, UNKNOWN_CONTACT_OPTION } from "@/constants/unknownContact";
+import { ResolveContactSection } from "./ResolveContactSection";
 
 
 // A flexible schema for all modes
@@ -91,7 +93,14 @@ export const EditTaskForm = ({ onSuccess }: { onSuccess?: () => void }) => {
   const { taskData, mode } = editTask.context;
 
   // console.log("taskDatasales",taskData)
-  
+
+  // When the task still points at the global "Unknown" placeholder, let the user
+  // resolve it inline (create the real contact + link it) without leaving this
+  // dialog. Once resolved we hold it locally so the panel hides and the header
+  // reflects the real contact immediately.
+  const [resolvedContact, setResolvedContact] = useState<{ name: string; first_name: string } | null>(null);
+  const isUnknownContact = !resolvedContact && taskData?.contact === UNKNOWN_CONTACT_ID;
+
   const { salesUserOptions, isLoading: usersLoading } = useUserRoleLists();
   const role = localStorage.getItem("role")
 
@@ -103,6 +112,8 @@ export const EditTaskForm = ({ onSuccess }: { onSuccess?: () => void }) => {
     taskData?.contact, // The ID of the contact from the task
    // Only run this fetch if taskData and its contact field exist
   );
+  // Prefer the just-resolved contact so the header updates without a refetch.
+  const displayContactName = resolvedContact?.first_name || contactDoc?.first_name;
   const form = useForm<EditTaskFormValues>({
     resolver: zodResolver(editTaskSchema),
     defaultValues: {},
@@ -111,9 +122,25 @@ export const EditTaskForm = ({ onSuccess }: { onSuccess?: () => void }) => {
   const selectedStatus = form.watch("status");
   const selectedReason = form.watch("reason");
 
-  const { data: contactsList, isLoading: contactsLoading } = useFrappeGetDocList<CRMContacts>("CRM Contacts", { filters: [["company", "=", contactDoc?.company]], fields: ["name", "first_name", "last_name"], limit: 0 });
+  // Filter by the task's company directly (the linked contact — e.g. the Unknown
+  // placeholder — may have no company, which would otherwise hide real contacts).
+  // Explicit "all-contacts-" SWR key so creating a contact (which mutates all
+  // "all-contacts-*" keys) invalidates this list and it refetches with the new one.
+  const { data: contactsList, isLoading: contactsLoading } = useFrappeGetDocList<CRMContacts>("CRM Contacts", { filters: [["company", "=", taskData?.company || contactDoc?.company]], fields: ["name", "first_name", "last_name"], limit: 0 }, `all-contacts-taskform-${taskData?.company || contactDoc?.company || ''}`);
 
-  const contactOptions = useMemo(() => contactsList?.map(c => ({ label: c.first_name, value: c.name })) || [], [contactsList]);
+  const contactOptions = useMemo(() => {
+    const options = contactsList?.map(c => ({ label: c.first_name, value: c.name })) || [];
+    // Show a just-resolved contact immediately, before the list cache refetches.
+    if (resolvedContact && !options.some(o => o.value === resolvedContact.name)) {
+      options.push({ label: resolvedContact.first_name, value: resolvedContact.name });
+    }
+    // Offer the global "Unknown" placeholder for follow-ups on companies with
+    // no real contact yet.
+    if (!options.some(o => o.value === UNKNOWN_CONTACT_OPTION.value)) {
+      options.push(UNKNOWN_CONTACT_OPTION);
+    }
+    return options;
+  }, [contactsList, resolvedContact]);
 
   useEffect(() => {
     if (taskData) {
@@ -144,6 +171,13 @@ export const EditTaskForm = ({ onSuccess }: { onSuccess?: () => void }) => {
       });
     }
   }, [taskData, form,mode]);
+
+  // Reflect a just-resolved contact in the (scheduleNext) contact dropdown.
+  useEffect(() => {
+    if (resolvedContact) {
+      form.setValue("contact", resolvedContact.name);
+    }
+  }, [resolvedContact, form]);
 
   // --- STEP 2: ADD A useEffect TO CLEAR/VALIDATE FIELDS ON CHANGE ---
   useEffect(() => {
@@ -205,7 +239,10 @@ export const EditTaskForm = ({ onSuccess }: { onSuccess?: () => void }) => {
           shouldCloseDialog = false; // Prevent the current dialog from closing
           // Immediately open the dialog again, but in the new 'scheduleNext' mode.
           // React will efficiently re-render the dialog's content.
-          openEditTaskDialog({ taskData, mode: 'scheduleNext' });
+          openEditTaskDialog({
+            taskData: { ...taskData, contact: resolvedContact?.name || taskData.contact },
+            mode: 'scheduleNext',
+          });
         }
       } else if (mode === 'scheduleNext') {
         await createDoc("CRM Task", {
@@ -213,7 +250,9 @@ export const EditTaskForm = ({ onSuccess }: { onSuccess?: () => void }) => {
           start_date:values.start_date,
           // time: values.time,
           status: 'Scheduled',
-          contact: values.contact||taskData.contact,
+          // Respect the user's explicit dropdown choice first (they may pick
+          // Unknown on purpose); fall back to a just-resolved contact, then the task's.
+          contact: values.contact || resolvedContact?.name || taskData.contact,
           company: taskData.company,
           task_profile:"Sales",
           assigned_sales: values.assigned_sales||taskData.assigned_sales,
@@ -257,7 +296,16 @@ export const EditTaskForm = ({ onSuccess }: { onSuccess?: () => void }) => {
   };
 
   return (
-    <Form {...form}>
+    <div className="space-y-4">
+      {/* --- RESOLVE UNKNOWN CONTACT (inline collapsible) --- */}
+      {isUnknownContact && taskData && (
+        <ResolveContactSection
+          companyId={taskData.company}
+          taskName={taskData.name}
+          onResolved={setResolvedContact}
+        />
+      )}
+      <Form {...form}>
       <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
 
         {/* --- RENDER FOR 'edit' or 'scheduleNext' MODE --- */}
@@ -266,7 +314,10 @@ export const EditTaskForm = ({ onSuccess }: { onSuccess?: () => void }) => {
             <div className="flex justify-between items-start text-sm mb-4 border-b pb-4">
               {/* Main Task Info */}
               <div className="flex flex-col gap-2">
-                <p className="font-semibold">{taskData?.type} for {contactDoc?.first_name}</p>
+                {mode === 'scheduleNext' && (
+                  <span className="text-[11px] font-semibold uppercase tracking-wide text-destructive underline underline-offset-2">Previous Task</span>
+                )}
+                <p className="font-semibold">{taskData?.type} for {displayContactName}</p>
 
                 {/* --- START: 2. ADDED UI ELEMENTS FOR DATE AND TIME --- */}
                 <div className="flex items-center gap-4 text-xs text-muted-foreground">
@@ -274,6 +325,12 @@ export const EditTaskForm = ({ onSuccess }: { onSuccess?: () => void }) => {
                     <Calendar className="w-3.5 h-3.5" />
                     <span>{formatDateWithOrdinal(taskData?.start_date)}</span>
                   </div>
+                  {taskData?.company && (
+                    <div className="flex items-center gap-1.5">
+                      <Building2 className="w-3.5 h-3.5" />
+                      <span>{taskData.company}</span>
+                    </div>
+                  )}
                   {/* <div className="flex items-center gap-1.5">
                     <Clock className="w-3.5 h-3.5" />
                     <span>{formatTime12Hour(taskData?.time)}</span>
@@ -329,7 +386,7 @@ export const EditTaskForm = ({ onSuccess }: { onSuccess?: () => void }) => {
         {mode === 'updateStatus' && (
           <>
             <div className="flex justify-between items-start text-sm mb-4 border-b pb-4">
-              <div className="flex flex-col gap-2"><p className="font-semibold">{taskData?.type} for {contactDoc?.first_name}</p><div className="flex items-center gap-4 text-xs text-muted-foreground"><div className="flex items-center gap-1.5"><Calendar className="w-3.5 h-3.5" /><span>{formatDateWithOrdinal(taskData?.start_date)}</span></div><div className="flex items-center gap-1.5"></div></div></div>
+              <div className="flex flex-col gap-2"><p className="font-semibold">{taskData?.type} for {displayContactName}</p><div className="flex items-center gap-4 text-xs text-muted-foreground"><div className="flex items-center gap-1.5"><Calendar className="w-3.5 h-3.5" /><span>{formatDateWithOrdinal(taskData?.start_date)}</span></div>{taskData?.company && (<div className="flex items-center gap-1.5"><Building2 className="w-3.5 h-3.5" /><span>{taskData.company}</span></div>)}</div></div>
               <span className="bg-yellow-100 text-yellow-800 px-2 py-1 rounded-full text-xs font-semibold whitespace-nowrap">{taskData?.status}</span>
             </div>
 
@@ -366,7 +423,8 @@ export const EditTaskForm = ({ onSuccess }: { onSuccess?: () => void }) => {
           <Button type="submit" className="bg-destructive hover:bg-destructive/90" disabled={loading}>{loading ? "Saving..." : "Confirm"}</Button>
         </div>
       </form>
-    </Form>
+      </Form>
+    </div>
   );
 };
 
@@ -567,7 +625,7 @@ export const EditTaskForm = ({ onSuccess }: { onSuccess?: () => void }) => {
 //           <>
 //             <div className="flex justify-between items-start text-sm mb-4 border-b pb-4">
 //               <div className="flex flex-col gap-2">
-//                 <p className="font-semibold">{taskData?.type} for {contactDoc?.first_name}</p>
+//                 <p className="font-semibold">{taskData?.type} for {displayContactName}</p>
 
 //                 <div className="flex items-center gap-4 text-xs text-muted-foreground">
 //                   <div className="flex items-center gap-1.5">
@@ -617,7 +675,7 @@ export const EditTaskForm = ({ onSuccess }: { onSuccess?: () => void }) => {
 //         {mode === 'updateStatus' && (
 //           <>
 //             <div className="flex justify-between items-start text-sm mb-4 border-b pb-4">
-//               <div className="flex flex-col gap-2"><p className="font-semibold">{taskData?.type} for {contactDoc?.first_name}</p><div className="flex items-center gap-4 text-xs text-muted-foreground"><div className="flex items-center gap-1.5"><Calendar className="w-3.5 h-3.5" /><span>{formatDate(taskData?.start_date)}</span></div><div className="flex items-center gap-1.5"><Clock className="w-3.5 h-3.5" /><span>{formatTime12Hour(taskData?.time)}</span></div></div></div>
+//               <div className="flex flex-col gap-2"><p className="font-semibold">{taskData?.type} for {displayContactName}</p><div className="flex items-center gap-4 text-xs text-muted-foreground"><div className="flex items-center gap-1.5"><Calendar className="w-3.5 h-3.5" /><span>{formatDate(taskData?.start_date)}</span></div><div className="flex items-center gap-1.5"><Clock className="w-3.5 h-3.5" /><span>{formatTime12Hour(taskData?.time)}</span></div></div></div>
 //               <span className="bg-yellow-100 text-yellow-800 px-2 py-1 rounded-full text-xs font-semibold whitespace-nowrap">{taskData?.status}</span>
 //             </div>
 

--- a/crm/src/pages/Tasks/NewTaskForm.tsx
+++ b/crm/src/pages/Tasks/NewTaskForm.tsx
@@ -14,6 +14,7 @@ import * as z from "zod";
 import ReactSelect from 'react-select';
 import { useMemo, useEffect } from "react";
 import { useUserRoleLists } from "@/hooks/useUserRoleLists"
+import { UNKNOWN_CONTACT_OPTION } from "@/constants/unknownContact";
 
 
 // import { taskTypeOptions } from "@/constants/dropdownData";
@@ -24,7 +25,7 @@ const taskFormSchema = z.object({
   start_date: z.string().min(1, "Date is required"),
   // time: z.string().min(1, "Time is required"),
   company: z.string().min(1, "Company is required"),
-  contact: z.string().optional(),
+  contact: z.string().min(1, "Contact is required"),
   boq: z.string().optional(),
   assigned_sales: z.string().optional(),
   remarks: z.string().min(1, "Remark is required"),
@@ -109,7 +110,15 @@ export const NewTaskForm = ({ onSuccess }: NewTaskFormProps) => {
 
   // --- OPTIONS FOR DROPDOWNS ---
   const companyOptions = useMemo(() => allCompanies?.map(c => ({ label: c.company_nick ? `${c.company_name} (${c.company_nick})` : c.company_name, value: c.name })) || [], [allCompanies]);
-  const contactOptions = useMemo(() => contactsList?.map(c => ({ label: c.first_name, value: c.name })) || [], [contactsList]);
+  const contactOptions = useMemo(() => {
+    const options = contactsList?.map(c => ({ label: c.first_name, value: c.name })) || [];
+    // Always offer the global "Unknown" placeholder so a task can still be
+    // logged for a company that has no real contact yet.
+    if (!options.some(o => o.value === UNKNOWN_CONTACT_OPTION.value)) {
+      options.push(UNKNOWN_CONTACT_OPTION);
+    }
+    return options;
+  }, [contactsList]);
   const boqOptions = useMemo(() => boqsList?.map(b => ({ label: b.boq_name, value: b.name })) || [], [boqsList]);
 
   // const taskTypeOptions = [ {label: "Meeting", value: "Meeting"}, {label: "Call", value: "Call"},{label: "Virtual", value: "Virtual"}, {label: "Follow-up", value: "Follow-up"} ];
@@ -187,7 +196,7 @@ export const NewTaskForm = ({ onSuccess }: NewTaskFormProps) => {
 
 
         {/* --- DYNAMIC CONTACT FIELD --- */}
-        <FormField name="contact" control={form.control} render={({ field }) => (<FormItem><FormLabel>Contact</FormLabel><FormControl>
+        <FormField name="contact" control={form.control} render={({ field }) => (<FormItem><FormLabel>Contact<sup>*</sup></FormLabel><FormControl>
           {contactIdFromContext ? (
             // If a contactId was provided directly, show its name disabled.
             <Input value={contactDocFromContext ? `${contactDocFromContext.first_name} ${contactDocFromContext.last_name}` : "Loading..."} disabled />

--- a/crm/src/pages/Tasks/ResolveContactSection.tsx
+++ b/crm/src/pages/Tasks/ResolveContactSection.tsx
@@ -1,0 +1,211 @@
+// Inline, collapsible "resolve the Unknown contact" panel shown inside the task
+// update dialog. On open it first lets the user SELECT an existing contact of
+// this company (the "Unknown" placeholder is excluded); if none fits they switch
+// to CREATE a new contact. Either way the chosen contact is linked to the task
+// directly — no second dialog.
+import { useState } from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import * as z from "zod";
+import ReactSelect from "react-select";
+import { useFrappeCreateDoc, useFrappeUpdateDoc, useFrappeGetDocList, useSWRConfig } from "frappe-react-sdk";
+import { ChevronDown, ChevronUp } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { toast } from "@/hooks/use-toast";
+import { useUserRoleLists } from "@/hooks/useUserRoleLists";
+import { CRMContacts } from "@/types/NirmaanCRM/CRMContacts";
+import { UNKNOWN_CONTACT_ID } from "@/constants/unknownContact";
+
+const resolveContactSchema = z.object({
+  first_name: z.string().min(1, "Name is required"),
+  last_name: z.string().optional(),
+  mobile: z.string().min(10, "Enter a valid mobile number").max(13, "Enter a valid mobile number"),
+  email: z.string().email("Enter a valid email address"),
+  designation: z.string().optional(),
+  department: z.string().optional(),
+  other_department: z.string().optional(),
+  linkedin_profile: z.string().url("Enter a valid URL").optional().or(z.literal("")),
+  assigned_sales: z.string().optional(),
+});
+type ResolveContactValues = z.infer<typeof resolveContactSchema>;
+
+const departmentOptions = [
+  { label: "Project", value: "Project" },
+  { label: "Quantity Survey Estimation", value: "Quantity Survey Estimation" },
+  { label: "Procurement", value: "Procurement" },
+  { label: "Senior Management", value: "Senior Management" },
+  { label: "Others", value: "Others" },
+];
+
+interface ResolveContactSectionProps {
+  companyId: string;
+  taskName: string;
+  onResolved: (contact: { name: string; first_name: string }) => void;
+}
+
+export const ResolveContactSection = ({ companyId, taskName, onResolved }: ResolveContactSectionProps) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const [subMode, setSubMode] = useState<"select" | "create">("select");
+  const [selectedExisting, setSelectedExisting] = useState<string | null>(null);
+
+  const { createDoc, loading: creating } = useFrappeCreateDoc();
+  const { updateDoc, loading: updating } = useFrappeUpdateDoc();
+  const { mutate } = useSWRConfig();
+  const role = localStorage.getItem("role");
+  const { salesUserOptions, isLoading: usersLoading } = useUserRoleLists();
+
+  // This company's real contacts (the Unknown placeholder has no company, so it
+  // is already out, but exclude it defensively).
+  const { data: companyContacts, isLoading: contactsLoading } = useFrappeGetDocList<CRMContacts>(
+    "CRM Contacts",
+    { filters: [["company", "=", companyId]], fields: ["name", "first_name", "last_name"], limit: 0 },
+    `all-contacts-resolve-${companyId}`
+  );
+  const existingOptions = (companyContacts || [])
+    .filter(c => c.name !== UNKNOWN_CONTACT_ID)
+    .map(c => ({ label: `${c.first_name} ${c.last_name || ""}`.trim(), value: c.name }));
+  const hasExisting = existingOptions.length > 0;
+  const showSelect = subMode === "select" && hasExisting;
+
+  const form = useForm<ResolveContactValues>({
+    resolver: zodResolver(resolveContactSchema),
+    defaultValues: {
+      first_name: "", last_name: "", mobile: "", email: "",
+      designation: "", department: "", other_department: "", linkedin_profile: "", assigned_sales: "",
+    },
+  });
+  const watchedDepartment = form.watch("department");
+  const loading = creating || updating;
+
+  // Link an already-existing contact of this company to the task.
+  const onLinkExisting = async () => {
+    if (!selectedExisting) return;
+    try {
+      await updateDoc("CRM Task", taskName, { contact: selectedExisting });
+      await mutate(key => typeof key === "string" && key.startsWith("all-tasks-"));
+      await mutate("CRM Task");
+      const chosen = companyContacts?.find(c => c.name === selectedExisting);
+      const firstName = chosen?.first_name || selectedExisting;
+      toast({ title: "Contact linked", description: `Task linked to "${firstName}".` });
+      setIsOpen(false);
+      onResolved({ name: selectedExisting, first_name: firstName });
+    } catch (error) {
+      toast({ title: "Error", description: (error as Error).message, variant: "destructive" });
+    }
+  };
+
+  // Create a brand-new contact and link it to the task.
+  const onCreate = async (values: ResolveContactValues) => {
+    try {
+      const department = values.department === "Others" ? values.other_department : values.department;
+      const newContact = await createDoc("CRM Contacts", {
+        first_name: values.first_name,
+        last_name: values.last_name || "",
+        mobile: values.mobile,
+        email: values.email,
+        company: companyId,
+        designation: values.designation || "",
+        department: department || "",
+        linkedin_profile: values.linkedin_profile || "",
+        // For Sales users the backend overwrites this with the owner; for Admin
+        // the picked value is kept (before_insert only stamps Sales users).
+        assigned_sales: values.assigned_sales || "",
+      });
+
+      await updateDoc("CRM Task", taskName, { contact: newContact.name });
+      await mutate(key => typeof key === "string" && key.startsWith("all-contacts-"));
+      await mutate(key => typeof key === "string" && key.startsWith("all-tasks-"));
+      await mutate("CRM Task");
+
+      toast({ title: "Contact resolved", description: `Task linked to "${newContact.first_name}".` });
+      setIsOpen(false);
+      form.reset();
+      onResolved({ name: newContact.name, first_name: newContact.first_name });
+    } catch (error) {
+      toast({ title: "Error", description: (error as Error).message, variant: "destructive" });
+    }
+  };
+
+  return (
+    <div className="rounded-md border border-amber-300 bg-amber-50 p-3">
+      <div className="flex items-center justify-between gap-3">
+        <div>
+          <p className="text-sm font-medium text-amber-900">This task's contact is “Unknown”.</p>
+          <p className="text-xs text-amber-700">Pick an existing contact for this company, or add a new one.</p>
+        </div>
+        <Button
+          type="button"
+          variant="outline"
+          className="border-amber-500 text-amber-900 hover:bg-amber-100 whitespace-nowrap"
+          onClick={() => setIsOpen(o => !o)}
+        >
+          Resolve Contact
+          {isOpen ? <ChevronUp className="ml-1 w-4 h-4" /> : <ChevronDown className="ml-1 w-4 h-4" />}
+        </Button>
+      </div>
+
+      {isOpen && (
+        <div className="mt-3 space-y-3 border-t border-amber-200 pt-3">
+          <p className="text-xs text-amber-800">Company: <span className="font-medium">{companyId}</span></p>
+
+          {contactsLoading ? (
+            <p className="text-sm text-amber-700">Loading contacts…</p>
+          ) : showSelect ? (
+            /* --- SELECT AN EXISTING COMPANY CONTACT --- */
+            <div className="space-y-3">
+              <div>
+                <label className="text-sm font-medium">Select existing contact</label>
+                <ReactSelect
+                  options={existingOptions}
+                  value={existingOptions.find(o => o.value === selectedExisting) || null}
+                  onChange={opt => setSelectedExisting(opt?.value || null)}
+                  placeholder="Select a contact from this company"
+                  menuPosition="auto"
+                />
+              </div>
+              <div className="flex items-center justify-between">
+                <Button type="button" variant="ghost" className="px-0 text-amber-900" onClick={() => setSubMode("create")}>
+                  + Create new contact
+                </Button>
+                <Button type="button" className="bg-destructive hover:bg-destructive/90" onClick={onLinkExisting} disabled={!selectedExisting || loading}>
+                  {loading ? "Linking…" : "Link Contact"}
+                </Button>
+              </div>
+            </div>
+          ) : (
+            /* --- CREATE A NEW CONTACT --- */
+            <Form {...form}>
+              <div className="space-y-3">
+                <FormField name="first_name" control={form.control} render={({ field }) => (<FormItem><FormLabel>Name<sup>*</sup></FormLabel><FormControl><Input placeholder="e.g. John Doe" {...field} /></FormControl><FormMessage /></FormItem>)} />
+                <FormField name="mobile" control={form.control} render={({ field }) => (<FormItem><FormLabel>Mobile<sup>*</sup></FormLabel><FormControl><Input type="tel" placeholder="e.g. 9876543210" {...field} /></FormControl><FormMessage /></FormItem>)} />
+                <FormField name="email" control={form.control} render={({ field }) => (<FormItem><FormLabel>Email<sup>*</sup></FormLabel><FormControl><Input type="email" placeholder="e.g. john@example.com" {...field} /></FormControl><FormMessage /></FormItem>)} />
+                <FormField name="designation" control={form.control} render={({ field }) => (<FormItem><FormLabel>Designation</FormLabel><FormControl><Input placeholder="e.g. Manager" {...field} /></FormControl><FormMessage /></FormItem>)} />
+                <FormField name="department" control={form.control} render={({ field }) => (<FormItem><FormLabel>Department</FormLabel><FormControl><ReactSelect options={departmentOptions} value={departmentOptions.find(d => d.value === field.value)} onChange={opt => field.onChange(opt?.value)} placeholder="Select Department" menuPosition="auto" /></FormControl><FormMessage /></FormItem>)} />
+                {watchedDepartment === "Others" && (
+                  <FormField name="other_department" control={form.control} render={({ field }) => (<FormItem><FormLabel>Specify department</FormLabel><FormControl><Input placeholder="Enter department" {...field} /></FormControl><FormMessage /></FormItem>)} />
+                )}
+                <FormField name="linkedin_profile" control={form.control} render={({ field }) => (<FormItem><FormLabel>LinkedIn Profile URL</FormLabel><FormControl><Input placeholder="https://linkedin.com/in/..." {...field} /></FormControl><FormMessage /></FormItem>)} />
+                {role === "Nirmaan Admin User Profile" && (
+                  <FormField name="assigned_sales" control={form.control} render={({ field }) => (<FormItem><FormLabel>Assigned Salesperson</FormLabel><FormControl><ReactSelect options={salesUserOptions} value={salesUserOptions.find(u => u.value === field.value)} onChange={val => field.onChange(val?.value)} placeholder="Select a salesperson..." isLoading={usersLoading} menuPosition="auto" /></FormControl><FormMessage /></FormItem>)} />
+                )}
+                <div className="flex gap-2 justify-end">
+                  {hasExisting && (
+                    <Button type="button" variant="ghost" className="mr-auto px-0 text-amber-900" onClick={() => setSubMode("select")}>
+                      ← Select existing
+                    </Button>
+                  )}
+                  <Button type="button" variant="outline" onClick={() => { setIsOpen(false); form.reset(); }} disabled={loading}>Cancel</Button>
+                  <Button type="button" className="bg-destructive hover:bg-destructive/90" onClick={form.handleSubmit(onCreate)} disabled={loading}>
+                    {loading ? "Saving…" : "Save Contact"}
+                  </Button>
+                </div>
+              </div>
+            </Form>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/nirmaan_crm/integrations/controllers/unknown_contact.py
+++ b/nirmaan_crm/integrations/controllers/unknown_contact.py
@@ -1,0 +1,8 @@
+# The single, global placeholder contact used when a company has no real
+# contact yet. Tasks can be attached to it so they can still be logged; a user
+# later resolves it to a real contact from the task-update dialog in the
+# frontend, which creates the contact and repoints the task's `contact` field.
+#
+# Keep this value in sync with UNKNOWN_CONTACT_ID in
+# crm/src/constants/unknownContact.ts
+UNKNOWN_CONTACT = "unknown@nirmaan.app"

--- a/nirmaan_crm/nirmaan_crm/doctype/crm_company/crm_company.py
+++ b/nirmaan_crm/nirmaan_crm/doctype/crm_company/crm_company.py
@@ -18,4 +18,45 @@ class CRMCompany(Document):
 			else:
 				pass
 
+	def on_update(self):
+		self._cascade_assigned_sales()
+
+	def _cascade_assigned_sales(self):
+		"""When the company's sales owner changes, hand every record that was
+		assigned to the OLD owner over to the NEW owner.
+
+		Covers CRM BOQ (Projects), CRM Task, and CRM Contacts — all of which
+		carry their own `assigned_sales` and are permission-filtered by it. Each
+		is matched by the company's `company` link AND `assigned_sales == old`,
+		so only the previous owner's records are reassigned; records deliberately
+		handed to someone else are left untouched.
+
+		Uses `frappe.db.set_value` (a direct bulk UPDATE) rather than loading and
+		saving each doc: this flips only `assigned_sales` without re-running
+		`CRM BOQ.on_update` (estimation/status/value cascade) or `CRM Task.on_update`,
+		and therefore cannot recurse back into this handler.
+		"""
+		before = self.get_doc_before_save()
+		if not before:
+			return  # brand new insert — nothing to cascade from
+
+		old = (before.assigned_sales or "").strip()
+		new = (self.assigned_sales or "").strip()
+		if old == new:
+			return  # assigned_sales unchanged — no-op on unrelated edits
+
+		if not old:
+			return  # no previous owner to hand over from
+
+		# Targeted reassignment: only records currently owned by the previous
+		# sales user (within this company) move to the new owner.
+		for doctype in ("CRM BOQ", "CRM Task", "CRM Contacts"):
+			frappe.db.set_value(
+				doctype,
+				{"company": self.name, "assigned_sales": old},
+				"assigned_sales",
+				new,
+				update_modified=False,
+			)
+
 

--- a/nirmaan_crm/patches.txt
+++ b/nirmaan_crm/patches.txt
@@ -15,3 +15,4 @@ nirmaan_crm.patches.v0_0.rename_legacy_boq_status_values
 nirmaan_crm.patches.v0_0.recompute_boq_status_from_estimations
 nirmaan_crm.patches.v0_0.revert_cascaded_done_estimations
 nirmaan_crm.patches.v0_0.recompute_boq_value_from_estimations
+nirmaan_crm.patches.v0_0.seed_unknown_contact

--- a/nirmaan_crm/patches/v0_0/seed_unknown_contact.py
+++ b/nirmaan_crm/patches/v0_0/seed_unknown_contact.py
@@ -1,0 +1,28 @@
+import frappe
+
+from nirmaan_crm.integrations.controllers.unknown_contact import UNKNOWN_CONTACT
+
+
+def execute():
+    """
+    Seed the single global 'Unknown' placeholder contact.
+
+    Tasks for companies that have no real contact yet can be attached to this
+    contact; a hook (reassign_unknown_tasks) swaps it for the real contact once
+    one is created. Idempotent — safe to re-run.
+    """
+    if frappe.db.exists("CRM Contacts", UNKNOWN_CONTACT):
+        return
+
+    contact = frappe.get_doc(
+        {
+            "doctype": "CRM Contacts",
+            "email": UNKNOWN_CONTACT,
+            "first_name": "Unknown",
+            "last_name": "",
+        }
+    )
+    contact.insert(ignore_permissions=True)
+    frappe.db.commit()
+
+    print(f"Seeded global placeholder contact '{UNKNOWN_CONTACT}'.")


### PR DESCRIPTION
Let a task be logged for a company that has no real contact yet, then resolve it later without leaving the task dialog.

- Seed one global "Unknown" placeholder contact (unknown@nirmaan.app) via patch; shared id in unknown_contact.py (UNKNOWN_CONTACT) mirrored by unknownContact.ts (UNKNOWN_CONTACT_ID).
- Offer "Unknown" in the sales task contact dropdowns; make Contact a required field on the Add New Task form.
- ResolveContactSection: inline collapsible panel in the task update dialog to select an existing company contact (Unknown excluded) or create a new one, linked to the task directly (no second dialog). Company auto-set from the task; Admin-only assigned_sales picker.
- Task dialog header shows the company and a "Previous Task" tag on follow-ups; contact list filters by the task's company and stays fresh via an all-contacts- SWR key.
- Resolution is manual/inline (no doc_events hook).
- Update backend + frontend CLAUDE.md docs.